### PR TITLE
GEOPY-175: codecov token not necessary anymore

### DIFF
--- a/.github/workflows/pytest-windows.yml
+++ b/.github/workflows/pytest-windows.yml
@@ -51,8 +51,7 @@ jobs:
     - name: pytest
       run: poetry run pytest --cov-report=xml --cov=geoh5py --cov-branch --cov-fail-under=80
     - name: Codecov
-      if: ${{ github.repository == 'MiraGeoscience/geoh5py' && success() && matrix.python_ver == '3.7' }}
+      if: ${{ success() && matrix.python_ver == '3.7' }}
       uses: codecov/codecov-action@v1.3.2
       with:
         name: GitHub
-        token: ${{secrets.CODECOV_UPLOAD_TOKEN}}


### PR DESCRIPTION
**GEOPY-175 - bring back codecov on geoh5py** 
 can run on PR from forks