### PR TITLE
GEOPY-258: fixup github workfow file for Unix

### DIFF
--- a/.github/workflows/pytest-unix-os.yml
+++ b/.github/workflows/pytest-unix-os.yml
@@ -2,6 +2,7 @@ name: pytest on Unix OS
 
 on:
   pull_request:
+    branches:
       - main
       - release/**
       - hotfix/**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,7 @@ repos:
     -   id: trailing-whitespace
         exclude: \.mdj$
     -   id: check-toml
+    -   id: check-yaml
 #    -   id: check-added-large-files # crashing on some configuration. To be investigated
     -   id: check-case-conflict
     -   id: check-merge-conflict


### PR DESCRIPTION
**GEOPY-258 - change required test platforms per branch** 
 fixup for https://github.com/MiraGeoscience/geoh5py/pull/102