### PR TITLE
Fix opening workspace without a Root with groups

### DIFF
--- a/geoh5py/io/h5_writer.py
+++ b/geoh5py/io/h5_writer.py
@@ -541,8 +541,8 @@ class H5Writer:
             entity.on_file = True
 
             if isinstance(entity, RootGroup):
-                if "Root" not in h5file[base].keys():
-                    h5file[base].create_group = "Root"
+                if "Root" in h5file[base]:
+                    del h5file[base]["Root"]
 
                 h5file[base]["Root"] = entity_handle
 

--- a/geoh5py/workspace/workspace.py
+++ b/geoh5py/workspace/workspace.py
@@ -388,6 +388,9 @@ class Workspace(AbstractContextManager):
                 uuids = self._io_call(H5Reader.fetch_uuids, entity_type, mode="r")
 
                 for uid in uuids:
+                    if isinstance(self.get_entity(uid)[0], Entity):
+                        continue
+
                     recovered_object = self.load_entity(uid, entity_type)
 
                     if isinstance(recovered_object, Entity):
@@ -795,6 +798,9 @@ class Workspace(AbstractContextManager):
 
         :return entity: Entity loaded from geoh5
         """
+        if isinstance(self.get_entity(uid)[0], Entity):
+            return self.get_entity(uid)[0]
+
         base_classes = {
             "group": Group,
             "object": ObjectBase,

--- a/tests/remove_root_test.py
+++ b/tests/remove_root_test.py
@@ -19,6 +19,8 @@
 import numpy as np
 from h5py import File
 
+from geoh5py.groups import ContainerGroup
+from geoh5py.io.utils import as_str_if_uuid
 from geoh5py.objects import Points
 from geoh5py.shared.utils import compare_entities
 from geoh5py.workspace import Workspace
@@ -32,7 +34,8 @@ def test_remove_root(tmp_path):
     h5file_path = tmp_path / r"testProject.geoh5"
 
     with Workspace(h5file_path) as workspace:
-        points = Points.create(workspace, vertices=xyz)
+        group = ContainerGroup.create(workspace)
+        points = Points.create(workspace, vertices=xyz, parent=group)
         data = points.add_data(
             {
                 "DataValues": {
@@ -49,24 +52,32 @@ def test_remove_root(tmp_path):
         group_name = "SomeGroup"
         data_group = points.add_data_to_group(data, group_name)
 
-        # Remove the root
-        with File(h5file_path, "r+") as project:
-            base = list(project.keys())[0]
-            del project[base]["Root"]
-            del project[base]["Groups"]
-            del project[base]["Types"]["Group types"]
+    # Remove the root
+    with File(h5file_path, "r+") as project:
+        base = list(project.keys())[0]
+        del project[base]["Root"]
+        del project[base]["Groups"][as_str_if_uuid(workspace.root.uid)]
+        del project[base]["Types"]["Group types"]
 
-        # Read the data back in from a fresh workspace
-        new_workspace = Workspace(h5file_path)
-
+    # Read the data back in from a fresh workspace
+    with Workspace(h5file_path) as new_workspace:
         rec_points = new_workspace.get_entity(points.name)[0]
-        rec_group = rec_points.find_or_create_property_group(name=group_name)
-        rec_data = new_workspace.get_entity(data[0].name)[0]
 
+        points.workspace.open()
         compare_entities(
             points,
             rec_points,
             ignore=["_parent", "_on_file", "_property_groups"],
         )
-        compare_entities(data[0], rec_data, ignore=["_parent", "_on_file"])
-        compare_entities(data_group, rec_group, ignore=["_parent", "_on_file"])
+        compare_entities(
+            data[0],
+            new_workspace.get_entity(data[0].name)[0],
+            ignore=["_parent", "_on_file"],
+        )
+        compare_entities(
+            data_group,
+            rec_points.find_or_create_property_group(name=group_name),
+            ignore=["_parent", "_on_file"],
+        )
+
+    points.workspace.close()

--- a/tests/remove_root_test.py
+++ b/tests/remove_root_test.py
@@ -52,6 +52,10 @@ def test_remove_root(tmp_path):
         group_name = "SomeGroup"
         data_group = points.add_data_to_group(data, group_name)
 
+        # Check no crash loading existing entity
+        assert workspace.load_entity(points.uid, "object")
+        assert len(workspace.fetch_children(None)) == 0
+
     # Remove the root
     with File(h5file_path, "r+") as project:
         base = list(project.keys())[0]
@@ -61,6 +65,7 @@ def test_remove_root(tmp_path):
 
     # Read the data back in from a fresh workspace
     with Workspace(h5file_path) as new_workspace:
+        assert len(new_workspace.fetch_children(new_workspace.root)) == 1
         rec_points = new_workspace.get_entity(points.name)[0]
 
         points.workspace.open()


### PR DESCRIPTION
**GEOPY-540 - UUID weakref crash if workspace_geoh5 present.**

Actual issue related to loading project tree recursively when the Root doesn't exist. Openning the workspace would always crash if Group/Objects were present. This was not an issue for new `geoh5` as always flat structures but would error loading the original `workspace_geoh5` file.

@sebhmg That's a pretty critical fix. Let's try to merge this in before you package again.