### PR TITLE
GEOPY-542: root written without reference to children after creation

### DIFF
--- a/geoh5py/workspace/workspace.py
+++ b/geoh5py/workspace/workspace.py
@@ -153,9 +153,7 @@ class Workspace(AbstractContextManager):
             return
 
         if self.geoh5.mode in ["r+", "a"]:
-            self._io_call(
-                H5Writer.save_entity, self.root, add_children=False, mode="r+"
-            )
+            self._io_call(H5Writer.save_entity, self.root, add_children=True, mode="r+")
         self.geoh5.close()
         self._geoh5 = None
 

--- a/tests/remove_root_test.py
+++ b/tests/remove_root_test.py
@@ -86,3 +86,6 @@ def test_remove_root(tmp_path):
         )
 
     points.workspace.close()
+
+    with Workspace(h5file_path) as new_workspace:
+        assert len(new_workspace.list_entities_name) == 5, "Issue re-building the Root."


### PR DESCRIPTION
GEOPY-542: Root group did not include the children, resulting in an empty workspace on the second read.