### PR TITLE
GEOPY-543: always import annotations from future

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,6 @@ repos:
     rev: v5.0.0
     hooks:
     -   id: rstcheck
-        exclude: (docs/templates)
         additional_dependencies: [sphinx]
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,15 +95,12 @@ repos:
         exclude: \.mdj$
     -   id: mixed-line-ending
     -   id: name-tests-test
--   repo: local
+-   repo: https://github.com/rstcheck/rstcheck
+    rev: v5.0.0
     hooks:
     -   id: rstcheck
-        name: rstcheck
-        entry: rstcheck
-        files: '.rst'
-        language: python
         exclude: (docs/templates)
-        additional_dependencies: [rstcheck, sphinx]
+        additional_dependencies: [sphinx]
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0
     hooks:

--- a/geoh5py/data/blob_data.py
+++ b/geoh5py/data/blob_data.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from .data import Data, PrimitiveTypeEnum
 
 

--- a/geoh5py/data/data_association_enum.py
+++ b/geoh5py/data/data_association_enum.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from enum import Enum
 
 

--- a/geoh5py/data/datetime_data.py
+++ b/geoh5py/data/datetime_data.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from .data import Data, PrimitiveTypeEnum
 
 

--- a/geoh5py/data/float_data.py
+++ b/geoh5py/data/float_data.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 from .data import DataType, PrimitiveTypeEnum
 from .numeric_data import NumericData
 

--- a/geoh5py/data/geometric_data_constants.py
+++ b/geoh5py/data/geometric_data_constants.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import uuid
 
 from .primitive_type_enum import PrimitiveTypeEnum

--- a/geoh5py/data/integer_data.py
+++ b/geoh5py/data/integer_data.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 from .data import PrimitiveTypeEnum
 from .numeric_data import NumericData
 

--- a/geoh5py/data/numeric_data.py
+++ b/geoh5py/data/numeric_data.py
@@ -14,6 +14,9 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
 from abc import ABC
 
 import numpy as np

--- a/geoh5py/data/primitive_type_enum.py
+++ b/geoh5py/data/primitive_type_enum.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from enum import Enum
 
 

--- a/geoh5py/data/referenced_data.py
+++ b/geoh5py/data/referenced_data.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from .data_type import DataType
 from .integer_data import IntegerData
 from .primitive_type_enum import PrimitiveTypeEnum

--- a/geoh5py/data/unknown_data.py
+++ b/geoh5py/data/unknown_data.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import uuid
 
 from .data import Data

--- a/geoh5py/groups/container_group.py
+++ b/geoh5py/groups/container_group.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import uuid
 
 from .group import Group, GroupType

--- a/geoh5py/groups/drillhole_group.py
+++ b/geoh5py/groups/drillhole_group.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import uuid
 
 from .group import Group, GroupType

--- a/geoh5py/groups/giftools_group.py
+++ b/geoh5py/groups/giftools_group.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import uuid
 
 from .group import Group, GroupType

--- a/geoh5py/groups/notype_group.py
+++ b/geoh5py/groups/notype_group.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import uuid
 
 from .group import Group, GroupType

--- a/geoh5py/objects/label.py
+++ b/geoh5py/objects/label.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import uuid
 
 from .object_base import ObjectBase, ObjectType

--- a/geoh5py/objects/notype_object.py
+++ b/geoh5py/objects/notype_object.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import uuid
 
 from .object_base import ObjectBase

--- a/geoh5py/objects/surveys/magnetics.py
+++ b/geoh5py/objects/surveys/magnetics.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import uuid
 
 from ..curve import Curve

--- a/geoh5py/shared/coord3d.py
+++ b/geoh5py/shared/coord3d.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import numpy as np
 
 

--- a/geoh5py/ui_json/constants.py
+++ b/geoh5py/ui_json/constants.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 from uuid import UUID
 
 from ..groups import PropertyGroup

--- a/tests/add_filename_data_test.py
+++ b/tests/add_filename_data_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import os
 from io import BytesIO
 

--- a/tests/color_map_test.py
+++ b/tests/color_map_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/copy_entity_test.py
+++ b/tests/copy_entity_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/copy_survey_dcip_test.py
+++ b/tests/copy_survey_dcip_test.py
@@ -18,6 +18,8 @@
 # pylint: disable=R0914
 
 
+from __future__ import annotations
+
 import numpy as np
 
 from geoh5py.objects import CurrentElectrode, PotentialElectrode

--- a/tests/create_block_model_test.py
+++ b/tests/create_block_model_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 
 from geoh5py.objects import BlockModel

--- a/tests/create_curve_data_test.py
+++ b/tests/create_curve_data_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 
 from geoh5py.objects import Curve

--- a/tests/create_drillhole_data_test.py
+++ b/tests/create_drillhole_data_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import random
 import string
 

--- a/tests/create_entity_parent_test.py
+++ b/tests/create_entity_parent_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 from geoh5py.groups import ContainerGroup
 from geoh5py.objects import Points
 from geoh5py.workspace import Workspace

--- a/tests/create_geo_image_test.py
+++ b/tests/create_geo_image_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/create_grid_2d_test.py
+++ b/tests/create_grid_2d_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 
 from geoh5py.objects import Grid2D

--- a/tests/create_group_test.py
+++ b/tests/create_group_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 from geoh5py.groups import ContainerGroup, SimPEGGroup
 from geoh5py.shared.utils import compare_entities
 from geoh5py.ui_json import constants, templates

--- a/tests/create_octree_test.py
+++ b/tests/create_octree_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 from geoh5py.objects import Octree
 from geoh5py.shared.utils import compare_entities
 from geoh5py.workspace import Workspace

--- a/tests/create_point_data_test.py
+++ b/tests/create_point_data_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/create_property_group_test.py
+++ b/tests/create_property_group_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 
 from geoh5py.objects import Curve

--- a/tests/create_reference_data_test.py
+++ b/tests/create_reference_data_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import random
 import string
 

--- a/tests/create_surface_data_test.py
+++ b/tests/create_surface_data_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 
 from geoh5py.objects import Surface

--- a/tests/create_survey_base_em_test.py
+++ b/tests/create_survey_base_em_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 from geoh5py.objects.surveys.electromagnetics.base import BaseEMSurvey
 from geoh5py.workspace import Workspace
 

--- a/tests/create_survey_dcip_test.py
+++ b/tests/create_survey_dcip_test.py
@@ -17,6 +17,8 @@
 
 # pylint: disable=R0914
 
+from __future__ import annotations
+
 import uuid
 
 import numpy as np

--- a/tests/create_survey_mt_test.py
+++ b/tests/create_survey_mt_test.py
@@ -18,6 +18,8 @@
 # pylint: disable=R0914
 
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/create_survey_tem_test.py
+++ b/tests/create_survey_tem_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import numpy as np

--- a/tests/create_survey_tipper_test.py
+++ b/tests/create_survey_tipper_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/create_workspace_test.py
+++ b/tests/create_workspace_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import pytest
 from h5py import File
 

--- a/tests/data_instantiation_test.py
+++ b/tests/data_instantiation_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import inspect
 
 import pytest

--- a/tests/delete_entity_test.py
+++ b/tests/delete_entity_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from gc import collect
 
 import numpy as np

--- a/tests/geoh5py_test.py
+++ b/tests/geoh5py_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import re
 from pathlib import Path
 

--- a/tests/groups_instantiation_test.py
+++ b/tests/groups_instantiation_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import inspect
 
 import pytest

--- a/tests/h5_non_ascii_filename_test.py
+++ b/tests/h5_non_ascii_filename_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import sys
 from os import path
 

--- a/tests/insert_drillhole_data_test.py
+++ b/tests/insert_drillhole_data_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 
 from geoh5py.objects import Drillhole

--- a/tests/io_utils_test.py
+++ b/tests/io_utils_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from uuid import uuid4
 
 import numpy as np

--- a/tests/io_write_test.py
+++ b/tests/io_write_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 from h5py import File
 
 from geoh5py.objects import Points

--- a/tests/modify_property_group_test.py
+++ b/tests/modify_property_group_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from abc import ABC
 
 import numpy as np

--- a/tests/monitored_update_test.py
+++ b/tests/monitored_update_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 
 from geoh5py.groups import ContainerGroup

--- a/tests/no_data_value_test.py
+++ b/tests/no_data_value_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 
 from geoh5py.objects import Points

--- a/tests/objects_instantiation_test.py
+++ b/tests/objects_instantiation_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import inspect
 
 import pytest

--- a/tests/remove_root_test.py
+++ b/tests/remove_root_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 from h5py import File
 

--- a/tests/save_modified_properties_test.py
+++ b/tests/save_modified_properties_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from unittest.mock import patch
 
 import numpy as np

--- a/tests/set_parent_test.py
+++ b/tests/set_parent_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 
 from geoh5py.groups import ContainerGroup

--- a/tests/shared_utils_test.py
+++ b/tests/shared_utils_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from geoh5py.shared.utils import iterable, iterable_message
 
 

--- a/tests/ui_json_test.py
+++ b/tests/ui_json_test.py
@@ -14,6 +14,9 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
 import json
 from copy import deepcopy
 from os import path

--- a/tests/ui_json_utils_test.py
+++ b/tests/ui_json_utils_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from copy import deepcopy
 
 import pytest

--- a/tests/user_comments_test.py
+++ b/tests/user_comments_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 from geoh5py.groups import ContainerGroup
 from geoh5py.objects import Points
 from geoh5py.workspace import Workspace

--- a/tests/validators_test.py
+++ b/tests/validators_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/weakref_test.py
+++ b/tests/weakref_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import weakref
 
 

--- a/tests/weakref_utils_test.py
+++ b/tests/weakref_utils_test.py
@@ -15,6 +15,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import weakref
 
 import pytest

--- a/tests/workspace_context_test.py
+++ b/tests/workspace_context_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 import pytest
 
 from geoh5py.objects import Points

--- a/tests/xyx_datatype_test.py
+++ b/tests/xyx_datatype_test.py
@@ -16,6 +16,8 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
+
 from geoh5py.data import DataType, GeometricDataConstants
 from geoh5py.workspace import Workspace
 


### PR DESCRIPTION
**GEOPY-543 - make sure typehints do no affect runtime and do not require imports**
and makes sure typehint are fully ignored at runtime
and not forcing imports