### PR TITLE
GEOPY-857

### DIFF
--- a/geoh5py/groups/group.py
+++ b/geoh5py/groups/group.py
@@ -75,7 +75,11 @@ class Group(Entity):
             self.comments.values = self.comments.values + [comment_dict]
 
     def copy_from_extent(
-        self, bounds: np.ndarray, parent=None, copy_children: bool = True
+        self,
+        bounds: np.ndarray,
+        parent=None,
+        copy_children: bool = True,
+        clear_cache: bool = False,
     ) -> Group | None:
         """
         Find indices of vertices within a rectangular bounds.
@@ -88,7 +92,10 @@ class Group(Entity):
         new_entity = self.copy(parent=parent, copy_children=False)
         for child in self.children:
             child.copy_from_extent(
-                bounds, parent=new_entity, copy_children=copy_children
+                bounds,
+                parent=new_entity,
+                copy_children=copy_children,
+                clear_cache=clear_cache,
             )
 
         if len(new_entity.children) == 0:

--- a/geoh5py/objects/object_base.py
+++ b/geoh5py/objects/object_base.py
@@ -239,11 +239,12 @@ class ObjectBase(Entity):
         ):
             return None
 
-        new_entity = self.copy(parent=parent, copy_children=copy_children)
+        new_entity = self.copy(
+            parent=parent, copy_children=copy_children, clear_cache=clear_cache
+        )
         new_entity.clip_by_extent(bounds)
 
         if clear_cache:
-            clear_array_attributes(self, recursive=copy_children)
             clear_array_attributes(new_entity, recursive=copy_children)
 
         return new_entity

--- a/geoh5py/objects/object_base.py
+++ b/geoh5py/objects/object_base.py
@@ -33,7 +33,7 @@ from ..data.primitive_type_enum import PrimitiveTypeEnum
 from ..groups import PropertyGroup
 from ..shared import Entity
 from ..shared.conversion import BaseConversion
-from ..shared.utils import mask_by_extent
+from ..shared.utils import clear_array_attributes, mask_by_extent
 from .object_type import ObjectType
 
 if TYPE_CHECKING:
@@ -220,7 +220,11 @@ class ObjectBase(Entity):
         ...
 
     def copy_from_extent(
-        self, bounds: np.ndarray, parent=None, copy_children: bool = True
+        self,
+        bounds: np.ndarray,
+        parent=None,
+        copy_children: bool = True,
+        clear_cache: bool = False,
     ) -> ObjectBase | None:
         """
         Find indices of vertices within a rectangular bounds.
@@ -236,7 +240,13 @@ class ObjectBase(Entity):
             return None
 
         new_entity = self.copy(parent=parent, copy_children=copy_children)
-        return new_entity.clip_by_extent(bounds)
+        new_entity.clip_by_extent(bounds)
+
+        if clear_cache:
+            clear_array_attributes(self, recursive=copy_children)
+            clear_array_attributes(new_entity, recursive=copy_children)
+
+        return new_entity
 
     def clip_by_extent(self, bounds: np.ndarray) -> ObjectBase | None:
         """

--- a/geoh5py/objects/surveys/direct_current.py
+++ b/geoh5py/objects/surveys/direct_current.py
@@ -103,13 +103,20 @@ class PotentialElectrode(Curve):
             return self.ab_cell_id.value_map
         return None
 
-    def copy(self, parent=None, copy_children: bool = True, **kwargs):
+    def copy(
+        self,
+        parent=None,
+        copy_children: bool = True,
+        clear_cache: bool = False,
+        **kwargs,
+    ):
         """
         Function to copy a survey to a different parent entity.
 
         :param parent: Target parent to copy the entity under. Copied to current
             :obj:`~geoh5py.shared.entity.Entity.parent` if None.
         :param copy_children: Create copies of all children entities along with it.
+        :param clear_cache: Clear array attributes after copy.
 
         :return entity: Registered Entity to the workspace.
         """
@@ -118,7 +125,12 @@ class PotentialElectrode(Curve):
 
         omit_list = ["_metadata", "_potential_electrodes", "_current_electrodes"]
         new_entity = parent.workspace.copy_to_parent(
-            self, parent, copy_children=copy_children, omit_list=omit_list, **kwargs
+            self,
+            parent,
+            copy_children=copy_children,
+            omit_list=omit_list,
+            clear_cache=clear_cache,
+            **kwargs,
         )
         setattr(new_entity, "_ab_cell_id", None)
         if new_entity.ab_cell_id is None and self.ab_cell_id is not None:
@@ -128,6 +140,7 @@ class PotentialElectrode(Curve):
             parent,
             copy_children=copy_children,
             omit_list=omit_list,
+            clear_cache=clear_cache,
         )
         setattr(new_currents, "_ab_cell_id", None)
         if (
@@ -240,13 +253,20 @@ class CurrentElectrode(PotentialElectrode):
         """
         return cls.__TYPE_UID
 
-    def copy(self, parent=None, copy_children: bool = True, **kwargs):
+    def copy(
+        self,
+        parent=None,
+        copy_children: bool = True,
+        clear_cache: bool = False,
+        **kwargs,
+    ):
         """
         Function to copy a survey to a different parent entity.
 
         :param parent: Target parent to copy the entity under. Copied to current
             :obj:`~geoh5py.shared.entity.Entity.parent` if None.
         :param copy_children: Create copies of all children entities along with it.
+        :param clear_cache: Clear array attributes after copy.
 
         :return entity: Registered Entity to the workspace.
         """

--- a/geoh5py/objects/surveys/electromagnetics/base.py
+++ b/geoh5py/objects/surveys/electromagnetics/base.py
@@ -193,13 +193,20 @@ class BaseEMSurvey(ObjectBase, ABC):
 
         return None
 
-    def copy(self, parent=None, copy_children: bool = True, **kwargs) -> BaseEMSurvey:
+    def copy(
+        self,
+        parent=None,
+        copy_children: bool = True,
+        clear_cache: bool = False,
+        **kwargs,
+    ) -> BaseEMSurvey:
         """
         Function to copy a AirborneTEMReceivers to a different parent entity.
 
         :param parent: Target parent to copy the entity under. Copied to current
             :obj:`~geoh5py.shared.entity.Entity.parent` if None.
         :param copy_children: Create copies of AirborneTEMReceivers along with it.
+        :param clear_cache: Clear array attributes after copy.
 
         :return entity: Registered AirborneTEMReceivers to the workspace.
         """
@@ -209,7 +216,12 @@ class BaseEMSurvey(ObjectBase, ABC):
         omit_list = ["_metadata", "_receivers", "_transmitters", "_base_stations"]
         metadata = self.metadata.copy()
         new_entity = parent.workspace.copy_to_parent(
-            self, parent, copy_children=copy_children, omit_list=omit_list, **kwargs
+            self,
+            parent,
+            copy_children=copy_children,
+            omit_list=omit_list,
+            clear_cache=clear_cache,
+            **kwargs,
         )
         metadata["EM Dataset"][new_entity.type] = new_entity.uid
         for associate in ["transmitters", "receivers", "base_stations"]:
@@ -221,6 +233,7 @@ class BaseEMSurvey(ObjectBase, ABC):
                     parent,
                     copy_children=copy_children,
                     omit_list=omit_list,
+                    clear_cache=clear_cache,
                 )
                 setattr(new_entity, associate, complement)
                 metadata["EM Dataset"][complement.type] = complement.uid

--- a/geoh5py/shared/concatenation.py
+++ b/geoh5py/shared/concatenation.py
@@ -180,13 +180,20 @@ class Concatenator(Group):  # pylint: disable=too-many-public-methods
         self._concatenated_object_ids = object_ids
         self.workspace.update_attribute(self, "concatenated_object_ids")
 
-    def copy(self, parent=None, copy_children: bool = True, **kwargs):
+    def copy(
+        self,
+        parent=None,
+        copy_children: bool = True,
+        clear_cache: bool = False,
+        **kwargs,
+    ):
         """
         Function to copy an entity to a different parent entity.
 
         :param parent: Target parent to copy the entity under. Copied to current
             :obj:`~geoh5py.shared.entity.Entity.parent` if None.
         :param copy_children: Create copies of all children entities along with it.
+        :param clear_cache: Clear array attributes after copy.
 
         :return entity: Registered Entity to the workspace.
         """
@@ -195,7 +202,7 @@ class Concatenator(Group):  # pylint: disable=too-many-public-methods
             parent = self.parent
 
         new_entity = parent.workspace.copy_to_parent(
-            self, parent, copy_children=False, **kwargs
+            self, parent, copy_children=False, clear_cache=clear_cache, **kwargs
         )
 
         if self.concatenated_attributes is None:

--- a/geoh5py/shared/entity.py
+++ b/geoh5py/shared/entity.py
@@ -168,7 +168,13 @@ class Entity(ABC):
         """
         return self._clipping_ids
 
-    def copy(self, parent=None, copy_children: bool = True, **kwargs):
+    def copy(
+        self,
+        parent=None,
+        copy_children: bool = True,
+        clear_cache: bool = False,
+        **kwargs,
+    ):
         """
         Function to copy an entity to a different parent entity.
 
@@ -183,7 +189,7 @@ class Entity(ABC):
             parent = self.parent
 
         new_entity = parent.workspace.copy_to_parent(
-            self, parent, copy_children=copy_children, **kwargs
+            self, parent, copy_children=copy_children, clear_cache=clear_cache, **kwargs
         )
 
         return new_entity

--- a/geoh5py/shared/utils.py
+++ b/geoh5py/shared/utils.py
@@ -161,6 +161,22 @@ def merge_arrays(
     return np.r_[head, tail]
 
 
+def clear_array_attributes(entity: Entity, recursive: bool = False):
+    """
+    Clear all attributes from an entity.
+
+    :param entity: Entity to clear attributes from.
+    :param recursive: Clear attributes from children entities.
+    """
+    for attribute in ["vertices", "cells", "values", "prisms", "layers"]:
+        if hasattr(entity, attribute):
+            setattr(entity, f"_{attribute}", None)
+
+    if recursive:
+        for child in entity.children:
+            clear_array_attributes(child, recursive=recursive)
+
+
 def compare_entities(
     object_a, object_b, ignore: list | None = None, decimal: int = 6
 ) -> None:

--- a/geoh5py/workspace/workspace.py
+++ b/geoh5py/workspace/workspace.py
@@ -63,6 +63,7 @@ from ..shared.entity import Entity
 from ..shared.exceptions import Geoh5FileClosedError
 from ..shared.utils import (
     as_str_if_utf8_bytes,
+    clear_array_attributes,
     get_attributes,
     overwrite_kwargs,
     str2uuid,
@@ -226,7 +227,7 @@ class Workspace(AbstractContextManager):
         parent,
         copy_children: bool = True,
         omit_list: tuple = (),
-        extent: np.ndarray | None = None,
+        clear_cache: bool = False,
         **kwargs,
     ):
         """
@@ -236,7 +237,7 @@ class Workspace(AbstractContextManager):
         :param parent: Target parent to copy the entity under.
         :param copy_children: Copy all children of the entity.
         :param omit_list: List of property names to omit on copy
-        :param extent: Clip object's copy by extent defined by a South-West and North-East corners.
+        :param clear_cache: Clear array attributes after copy.
         :param kwargs: Additional keyword arguments passed to the copy constructor.
 
         :return: The Entity registered to the workspace.
@@ -292,7 +293,7 @@ class Workspace(AbstractContextManager):
             children_map = {}
             for child in entity.children:
                 new_child = self.copy_to_parent(
-                    child, new_object, copy_children=True, extent=extent
+                    child, new_object, copy_children=True, clear_cache=clear_cache
                 )
                 new_object.add_children([new_child])
                 children_map[child.uid] = new_child.uid
@@ -300,6 +301,9 @@ class Workspace(AbstractContextManager):
             if prop_groups:
                 self.copy_property_groups(new_object, prop_groups, children_map)
                 self.workspace.update_attribute(new_object, "property_groups")
+
+        if clear_cache:
+            clear_array_attributes(entity)
 
         return new_object
 

--- a/tests/clip_vertex_data_test.py
+++ b/tests/clip_vertex_data_test.py
@@ -116,8 +116,8 @@ def test_clip_groups(tmp_path):
     ].T
     h5file_path = tmp_path / r"testClipGroup.geoh5"
     with Workspace(h5file_path) as workspace:
-        group_a = ContainerGroup.create(workspace, name="GroupA")
-        group_b = ContainerGroup.create(workspace, name="GroupB", parent=group_a)
+        group_a = ContainerGroup.create(workspace, name="Group A")
+        group_b = ContainerGroup.create(workspace, name="Group B", parent=group_a)
         curve_a = Curve.create(workspace, vertices=vertices, parent=group_a)
         curve_b = Curve.create(
             workspace, vertices=np.c_[1000.0, 1000.0, 0.0], parent=group_b
@@ -136,10 +136,15 @@ def test_clip_groups(tmp_path):
                 },
             }
         )
+
         with Workspace(tmp_path / r"testClipPoints_copy.geoh5") as new_workspace:
-            group_a.copy_from_extent(extent, parent=new_workspace)
+            group_a.copy_from_extent(extent, parent=new_workspace, clear_cache=True)
 
             assert (
                 len(new_workspace.objects) == 1
             ), "Error removing curve without nodes."
             assert len(new_workspace.groups) == 2, "Error removing empty group."
+
+            assert (
+                getattr(new_workspace.groups[0].children[0], "_vertices", None) is None
+            )


### PR DESCRIPTION
**GEOPY-857 - clip by extent fails with memory error on large file**
@sebhmg I added an argument to clear attributes on copy. Should solve your issue... unless you can't load the original object with its data. Otherwise will need to slice at the source.