### PR TITLE
catch properties bad instantiation when copying

### DIFF
--- a/geoh5py/groups/property_group.py
+++ b/geoh5py/groups/property_group.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import uuid
 from abc import ABC
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 from geoh5py.data import Data, DataAssociationEnum
@@ -186,6 +187,9 @@ class PropertyGroup(ABC):
                 "Cannot modify properties of an existing property group. "
                 "Consider using 'add_properties'."
             )
+
+        if not isinstance(uids, Iterable):
+            return
 
         properties = []
         for uid in uids:

--- a/tests/property_group_test.py
+++ b/tests/property_group_test.py
@@ -30,6 +30,7 @@ from geoh5py.workspace import Workspace
 
 def test_create_property_group(tmp_path):
     #  pylint: disable=too-many-locals
+    # pylint: disable=too-many-statements
 
     h5file_path = tmp_path / r"prop_group_test.geoh5"
 
@@ -60,7 +61,10 @@ def test_create_property_group(tmp_path):
 
         # test properties group
         curve2 = curve.copy()
+
         prop_group2 = curve2.find_or_create_property_group(name="myGroup2")
+
+        _ = curve2.copy()
 
         assert prop_group2.remove_properties("bidon") is None
 
@@ -144,6 +148,7 @@ def test_create_property_group(tmp_path):
         # assert workspace.get_entity("myGroup")[0].uid == property_group_test.uid
 
         rec_object = workspace.get_entity(curve.uid)[0]
+
         # Read the property_group back in
         rec_prop_group = rec_object.find_or_create_property_group(name="myGroup")
 
@@ -153,6 +158,7 @@ def test_create_property_group(tmp_path):
             for attr in attrs.values()
             if getattr(rec_prop_group, attr) != getattr(prop_group, attr)
         ]
+
         assert (
             len(check_list) == 0
         ), f"Attribute{check_list} of PropertyGroups in output differ from input"


### PR DESCRIPTION
**GEOPY-1042 - cannot create several property groups**
An error was raised when a property group with no associated data was added to an object, and when the user tried to copy such object. 

Catch by verifying the input of properties. 