### PR TITLE
Simplify logic. Adjust tests to work on name AND type.name

### DIFF
--- a/.github/workflows/pytest-unix-os.yml
+++ b/.github/workflows/pytest-unix-os.yml
@@ -2,12 +2,6 @@ name: pytest on Unix OS
 
 on:
   pull_request:
-    branches:
-      - develop
-      - main
-      - release/**
-      - feature/**
-      - hotfix/**
   push:
     branches:
       - develop

--- a/.github/workflows/pytest-windows.yml
+++ b/.github/workflows/pytest-windows.yml
@@ -2,12 +2,6 @@ name: pytest on Windows
 
 on:
   pull_request:
-    branches:
-      - develop
-      - main
-      - release/**
-      - feature/**
-      - hotfix/**
   push:
     branches:
       - develop

--- a/geoh5py/shared/merging/base.py
+++ b/geoh5py/shared/merging/base.py
@@ -60,7 +60,7 @@ class BaseMerger(ABC):
                 if label in data_dict:
                     values = data_dict[label].values
                     if isinstance(values, np.ndarray) and ~np.all(
-                        np.isnan(values[start:end])
+                        values[start:end] == data.nan_value
                     ):
                         label = (
                             data.name + f"({ind})",

--- a/geoh5py/shared/merging/base.py
+++ b/geoh5py/shared/merging/base.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from warnings import warn
 
 import numpy as np
 
@@ -59,13 +60,25 @@ class BaseMerger(ABC):
                 # Increment label in case of duplicate match
                 if label in data_dict:
                     values = data_dict[label].values
-                    if isinstance(values, np.ndarray) and ~np.all(
-                        values[start:end] == data.nan_value
+                    if isinstance(values, np.ndarray) and (
+                        ~np.all(
+                            np.logical_or(
+                                values[start:end] == data.nan_value,
+                                np.isnan(values[start:end]),
+                            )
+                        )
                     ):
                         label = (
                             data.name + f"({ind})",
                             data.entity_type.name,
                             association,
+                        )
+                        warn(
+                            f"Multiple data '{data.name}' with entity_type "
+                            f"name '{data.entity_type.name}' "
+                            f"were found on object '{input_entity.name}'. "
+                            f"The merging operation is ambiguous. "
+                            f"Please validate or rename the data."
                         )
 
                 if label not in data_dict:

--- a/geoh5py/shared/merging/base.py
+++ b/geoh5py/shared/merging/base.py
@@ -87,10 +87,7 @@ class BaseMerger(ABC):
                 values = data_dict[label].values
 
                 if isinstance(values, np.ndarray):
-                    values[
-                        data_count[association] : data_count[association]
-                        + data.n_values
-                    ] = data.values
+                    values[start:end] = data.values
                     data_dict[label].values = values
 
             data_count["VERTEX"] += (

--- a/geoh5py/shared/merging/base.py
+++ b/geoh5py/shared/merging/base.py
@@ -17,11 +17,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import cast
 
 import numpy as np
 
-from ...data import Data
+from ...data import NumericData
 from ...objects import ObjectBase
 from ...workspace import Workspace
 
@@ -30,150 +29,76 @@ class BaseMerger(ABC):
     _type: type = ObjectBase
 
     @classmethod
-    def number_of_keys(cls, type_list: list[entity_type], nb_keys: int) -> int:
-        """
-        Get the number of keys to use in the definition of the entity type.
-        
-        :param entity_unique_entity_types: the unique entity types generated
-            by extract_data_information().
-        :param nb_keys: the number of keys to use to define the entity type.
-        :return: the number of keys to use in the definition of the entity type.
-        """
-
-        # define how to define the entity_type
-        if nb_keys != 3 and len(
-            list({unique_type[:nb_keys] for unique_type in entity_unique_entity_types})
-        ) != len(entity_unique_entity_types):
-            nb_keys = 2
-            if len(list(set(entity_unique_entity_types))) != len(
-                entity_unique_entity_types
-            ):
-                nb_keys = 3
-
-        return nb_keys
-
-    @classmethod
-    def create_add_data_dictionary(
-        cls,
-        data_array: np.ndarray,
-        unique_entity_types: list,
-        unique_associations: dict,
-        nb_keys: int,
-    ):
-        """
-        Create the dictionary of data to add to the merged object.
-
-        :param data_array: the array containing the data to be merged.
-        :param unique_entity_types: the unique entity types generated
-        :param unique_associations: the unique associations generated
-        :param nb_keys: the number of keys to use to define the entity type.
-        :return: a dictionary of data to add to the merged object.
-        """
-
-        # create the output data
-        add_data_dict = {}
-        for id_, data in enumerate(data_array):
-            # define the association
-            association = unique_associations[unique_entity_types[id_]]
-
-            if not len(set(association)) == 1:
-                raise ValueError(
-                    f"Cannot merge data with different associations: {set(association)}"
-                )
-
-            # define the name
-            if nb_keys == 3:
-                name = f"merged_{unique_entity_types[id_][0].name}_{id_}"
-            elif nb_keys == 2:
-                name = f"merged_{unique_entity_types[id_][0].name}_{unique_entity_types[id_][1]}"
-            else:
-                name = f"merged_{unique_entity_types[id_][0].name}"
-
-            add_data_dict[name] = {
-                "association": association[0],
-                "values": data,
-                "entity_type": unique_entity_types[id_][0],
-            }
-
-        return add_data_dict
-
-    @classmethod
-    def extract_data_information(cls, input_entities: list[ObjectBase]) -> tuple:
-        """
-        Extract the information from data of the input entities.
-        :param input_entities: the list of the object to extract the data from.
-        :return: a tuple containing a list of the data information,
-            the unique entity types for each data,
-            the total length of the vertices,
-            and the number of keys to use to define the entity type.
-        """
-        # extract the data from the input entities
-        id_, previous, nb_keys = 0, 0, 1
-        all_data, unique_entity_types = [], []
-        for input_entity in input_entities:
-            entity_unique_entity_types = []
-
-            for data in input_entity.children:
-                if not isinstance(data, Data):
-                    continue
-                if data.name == "Visual Parameters":
-                    continue
-
-                all_data.append(
-                    [
-                        data.values,
-                        (data.entity_type, data.name, id_),
-                        data.association,
-                        previous,
-                        previous + cast(int, input_entity.n_vertices),
-                    ]
-                )
-                entity_unique_entity_types.append((data.entity_type, data.name))
-                unique_entity_types.append((data.entity_type, data.name, id_))
-                id_ += 1
-
-            # define how to define the entity_type
-            nb_keys = cls.compute_nb_keys(entity_unique_entity_types, nb_keys)
-            previous += cast(int, input_entity.n_vertices)
-
-        # create an intermediate array
-        all_data = np.array(all_data, dtype=object)
-
-        # prepare the attributes
-        unique_entity_types = list(
-            dict.fromkeys(
-                [entity_type[:nb_keys] for entity_type in unique_entity_types]  # type: ignore
-            )
-        )
-
-        return all_data, unique_entity_types, previous, nb_keys
-
-    @classmethod
-    def merge_data(cls, input_entities: list[ObjectBase]) -> dict[str, dict]:
+    def merge_data(cls, out_entity, input_entities: list[ObjectBase]):
         """
         Merge the data respecting the entity type, the values, and the association.
 
          :param input_entities: the list of objects to merge the data from.
         :return: a dictionary of data to add to the merged object.
         """
+        data_dict: dict[tuple, NumericData] = {}
+        data_count = {"VERTEX": 0, "CELL": 0}
 
-        # extract the data from the input entities
-        (
-            all_data,
-            unique_entity_types,
-            total_length,
-            nb_keys,
-        ) = cls.extract_data_information(input_entities)
+        for input_entity in input_entities:
+            for ind, data in enumerate(input_entity.children):
+                if (
+                    not isinstance(data, NumericData)
+                    or data.association is None
+                    or data.n_values is None
+                    or data.values is None
+                ):
+                    continue
 
-        # prepare the attributes
-        data_array, unique_associations = cls.prepare_attributes(
-            unique_entity_types, all_data, total_length, nb_keys
-        )
+                association = data.association.name
+                label = (data.name, data.entity_type.name, association)
+                start, end = (
+                    data_count[association],
+                    data_count[association] + data.n_values,
+                )
 
-        # create the output data
-        return cls.create_add_data_dictionary(
-            data_array, unique_entity_types, unique_associations, nb_keys
-        )
+                # Increment label in case of duplicate match
+                if label in data_dict:
+                    values = data_dict[label].values
+                    if isinstance(values, np.ndarray) and ~np.all(
+                        np.isnan(values[start:end])
+                    ):
+                        label = (
+                            data.name + f"({ind})",
+                            data.entity_type.name,
+                            association,
+                        )
+
+                if label not in data_dict:
+                    shape = (
+                        out_entity.n_vertices
+                        if association == "VERTEX"
+                        else out_entity.n_cells
+                    )
+                    data_dict[label] = out_entity.add_data(
+                        {
+                            data.name: {
+                                "values": np.ones(shape) * data.nan_value,
+                                "association": association,
+                                "entity_type": data.entity_type,
+                            }
+                        }
+                    )
+
+                values = data_dict[label].values
+
+                if isinstance(values, np.ndarray):
+                    values[
+                        data_count[association] : data_count[association]
+                        + data.n_values
+                    ] = data.values
+                    data_dict[label].values = values
+
+            data_count["VERTEX"] += (
+                input_entity.n_vertices if input_entity.n_vertices is not None else 0
+            )
+            data_count["CELL"] += (
+                input_entity.n_cells if input_entity.n_cells is not None else 0
+            )
 
     @classmethod
     def merge_objects(
@@ -204,7 +129,7 @@ class BaseMerger(ABC):
 
         # add the data
         if add_data:
-            output.add_data(cls.merge_data(input_entities))
+            cls.merge_data(output, input_entities)
 
         return output
 

--- a/tests/merger_test.py
+++ b/tests/merger_test.py
@@ -218,7 +218,7 @@ def test_merge_point_data_unique_entity_name_unique_name(tmp_path):
                 {
                     "DataValues": {
                         "association": "VERTEX",
-                        "values": np.random.randn(10),
+                        "values": np.random.randint(10, size=10),
                     }
                 }
             )
@@ -231,7 +231,7 @@ def test_merge_point_data_unique_entity_name_unique_name(tmp_path):
                 {
                     "DataValues": {
                         "association": "VERTEX",
-                        "values": np.random.randn(10),
+                        "values": np.random.randint(10, size=10),
                         "entity_type": entity_type,
                     }
                 }
@@ -247,7 +247,7 @@ def test_merge_point_data_unique_entity_name_unique_name(tmp_path):
                 {
                     "DataValues": {
                         "association": "VERTEX",
-                        "values": np.random.randn(10),
+                        "values": np.random.randint(10, size=10),
                         "entity_type": entity_type,
                     }
                 }
@@ -264,21 +264,25 @@ def test_merge_point_data_unique_entity_name_unique_name(tmp_path):
             )
         )
 
-        test = PointsMerger.merge_objects(workspace, points)
+        with pytest.warns(UserWarning, match=f"Multiple data '{data[0].name}'"):
+            test = PointsMerger.merge_objects(workspace, points)
 
-        nan_array = np.empty(10)
-        nan_array[:] = np.nan
+        int_nan_array = np.empty(10)
+        int_nan_array[:] = data[0].nan_value
+
+        float_nan_array = np.empty(10)
+        float_nan_array[:] = np.nan
 
         np.testing.assert_almost_equal(
             test.children[0].values, np.hstack((data[0].values, data[2].values))
         )
 
         np.testing.assert_almost_equal(
-            test.children[1].values, np.hstack((data[1].values, nan_array))
+            test.children[1].values, np.hstack((data[1].values, int_nan_array))
         )
 
         np.testing.assert_almost_equal(
-            test.children[2].values, np.hstack((nan_array, data[3].values))
+            test.children[2].values, np.hstack((float_nan_array, data[3].values))
         )
 
 

--- a/tests/merger_test.py
+++ b/tests/merger_test.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from geoh5py.data import Data
 from geoh5py.groups import PropertyGroup
 from geoh5py.objects import Points, Surface
 from geoh5py.shared.merging import PointsMerger
@@ -81,7 +80,7 @@ def test_merge_point_data_unique_entity(tmp_path):
         data.append(
             points[1].add_data(
                 {
-                    "DataValues2": {
+                    "DataValues0": {
                         "association": "VERTEX",
                         "values": np.random.randn(10),
                         "entity_type": entity_type,
@@ -106,28 +105,16 @@ def test_merge_point_data_unique_entity(tmp_path):
         nan_array[:] = np.nan
 
         # sort the dictionary by its keys
-        merged_data = list(
-            dict(
-                sorted(
-                    {
-                        child.name: child.values
-                        for child in test.children
-                        if isinstance(child, Data)
-                    }.items()
-                )
-            ).values()
+        np.testing.assert_almost_equal(
+            test.children[0].values, np.hstack((data[0].values, data[2].values))
         )
 
         np.testing.assert_almost_equal(
-            merged_data[0], np.hstack((data[0].values, data[2].values))
+            test.children[1].values, np.hstack((data[1].values, nan_array))
         )
 
         np.testing.assert_almost_equal(
-            merged_data[1], np.hstack((data[1].values, nan_array))
-        )
-
-        np.testing.assert_almost_equal(
-            merged_data[2], np.hstack((nan_array, data[3].values))
+            test.children[2].values, np.hstack((nan_array, data[3].values))
         )
 
 
@@ -201,28 +188,16 @@ def test_merge_point_data_unique_entity_name(tmp_path):
         nan_array[:] = np.nan
 
         # sort the dictionary by its keys
-        merged_data = list(
-            dict(
-                sorted(
-                    {
-                        child.name: child.values
-                        for child in test.children
-                        if isinstance(child, Data)
-                    }.items()
-                )
-            ).values()
+        np.testing.assert_almost_equal(
+            test.children[0].values, np.hstack((data[0].values, data[2].values))
         )
 
         np.testing.assert_almost_equal(
-            merged_data[1], np.hstack((data[0].values, data[2].values))
+            test.children[1].values, np.hstack((data[1].values, nan_array))
         )
 
         np.testing.assert_almost_equal(
-            merged_data[2], np.hstack((data[1].values, nan_array))
-        )
-
-        np.testing.assert_almost_equal(
-            merged_data[0], np.hstack((nan_array, data[3].values))
+            test.children[2].values, np.hstack((nan_array, data[3].values))
         )
 
 
@@ -294,33 +269,16 @@ def test_merge_point_data_unique_entity_name_unique_name(tmp_path):
         nan_array = np.empty(10)
         nan_array[:] = np.nan
 
-        # sort the dictionary by its keys
-        merged_data = list(
-            dict(
-                sorted(
-                    {
-                        child.name: child.values
-                        for child in test.children
-                        if isinstance(child, Data)
-                    }.items()
-                )
-            ).values()
+        np.testing.assert_almost_equal(
+            test.children[0].values, np.hstack((data[0].values, data[2].values))
         )
 
         np.testing.assert_almost_equal(
-            merged_data[0], np.hstack((nan_array, data[3].values))
+            test.children[1].values, np.hstack((data[1].values, nan_array))
         )
 
         np.testing.assert_almost_equal(
-            merged_data[1], np.hstack((data[0].values, nan_array))
-        )
-
-        np.testing.assert_almost_equal(
-            merged_data[2], np.hstack((data[1].values, nan_array))
-        )
-
-        np.testing.assert_almost_equal(
-            merged_data[3], np.hstack((nan_array, data[2].values))
+            test.children[2].values, np.hstack((nan_array, data[3].values))
         )
 
 
@@ -362,11 +320,6 @@ def test_merge_attribute_error(tmp_path):
             )
         )
 
-        with pytest.raises(
-            ValueError, match="Cannot merge data with different associations"
-        ):
-            _ = PointsMerger.merge_objects(workspace, points)
-
         with pytest.raises(TypeError, match="The input entities must be a list"):
             _ = PointsMerger.merge_objects(workspace, "bidon")
 
@@ -393,24 +346,3 @@ def test_merge_attribute_error(tmp_path):
 
         with pytest.raises(AttributeError, match="All entities must have vertices"):
             _ = PointsMerger.merge_objects(workspace, points)
-
-        point = Points.create(
-            workspace,
-            vertices=np.random.randn(10, 3),
-            allow_move=False,
-            name="visual parameter",
-        )
-
-        point.add_data(
-            {
-                "Visual Parameters": {
-                    "association": "VERTEX",
-                    "values": np.random.randn(10),
-                }
-            }
-        )
-
-        res = PointsMerger.extract_data_information([point])
-
-        assert (res[0] == np.array([], dtype=object)).all()
-        assert res[1:] == ([], 10, 1)


### PR DESCRIPTION
This modification should handle both vertex and cell association. We might want to split the merge data into two methods (one for each), but the idea is there.