### PR TITLE
GEOPY-1106 - pathlib in ui.json utils

### DIFF
--- a/geoh5py/ui_json/utils.py
+++ b/geoh5py/ui_json/utils.py
@@ -310,7 +310,7 @@ def workspace2path(value):
 
 
 def path2workspace(value):
-    if isinstance(value, str) and ".geoh5" in value:
+    if isinstance(value, (str, Path)) and Path(value).suffix == ".geoh5":
         workspace = Workspace(value, mode="r")
         workspace.close()
         return workspace


### PR DESCRIPTION
**GEOPY-1106 - path2workspace, use Pathlib Path suffix**
use pathlib to get suffix instead of strings in path2workspace in ui.json utils