### PR TITLE
GEOPY-444: print replaced by logger

### DIFF
--- a/geoh5py/objects/surveys/direct_current.py
+++ b/geoh5py/objects/surveys/direct_current.py
@@ -16,6 +16,7 @@
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 
+import logging
 import uuid
 from abc import ABC, abstractmethod
 from typing import cast
@@ -23,9 +24,10 @@ from typing import cast
 import numpy as np
 
 from ...data import Data, ReferencedData
-from ...shared import logger
 from ..curve import Curve
 from ..object_type import ObjectType
+
+logger = logging.getLogger(__name__)
 
 
 class BaseElectrode(Curve, ABC):

--- a/geoh5py/objects/surveys/direct_current.py
+++ b/geoh5py/objects/surveys/direct_current.py
@@ -23,6 +23,7 @@ from typing import cast
 import numpy as np
 
 from ...data import Data, ReferencedData
+from ...shared import logger
 from ..curve import Curve
 from ..object_type import ObjectType
 
@@ -64,7 +65,7 @@ class BaseElectrode(Curve, ABC):
                 self._ab_cell_id = cast(ReferencedData, data.copy(parent=self))
         else:
             if data.dtype != np.int32:
-                print("ab_cell_id values will be converted to type 'int32'")
+                logger.info("ab_cell_id values will be converted to type 'int32'")
 
             if any(self.get_data("A-B Cell ID")):
                 child = self.get_data("A-B Cell ID")[0]

--- a/geoh5py/shared/__init__.py
+++ b/geoh5py/shared/__init__.py
@@ -17,8 +17,6 @@
 
 # pylint: disable=unused-import
 # flake8: noqa
-import logging
-
 from . import weakref_utils
 from .entity import Entity
 from .entity_type import EntityType
@@ -26,5 +24,3 @@ from .utils import fetch_h5_handle, match_values, merge_arrays
 
 INTEGER_NDV = -2147483648
 FLOAT_NDV = 1.17549435e-38
-
-logger = logging.getLogger(__name__)

--- a/geoh5py/shared/__init__.py
+++ b/geoh5py/shared/__init__.py
@@ -17,6 +17,7 @@
 
 # pylint: disable=unused-import
 # flake8: noqa
+import logging
 
 from . import weakref_utils
 from .entity import Entity
@@ -25,3 +26,5 @@ from .utils import fetch_h5_handle, match_values, merge_arrays
 
 INTEGER_NDV = -2147483648
 FLOAT_NDV = 1.17549435e-38
+
+logger = logging.getLogger(__name__)


### PR DESCRIPTION
**GEOPY-444 - Use logging instead of print**
Should we change warning to logger.warning?

Change from sprint 63 to sprint 62. I don't have the access
