### PR TITLE
GEOPY-1129 remove obsolete python version from github tests

### DIFF
--- a/.github/workflows/pytest-unix-os.yml
+++ b/.github/workflows/pytest-unix-os.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_ver: ['3.8', '3.9', '3.10']
+        python_ver: ['3.9', '3.10']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/pytest-windows.yml
+++ b/.github/workflows/pytest-windows.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_ver: ['3.8', '3.9', '3.10']
+        python_ver: ['3.9', '3.10']
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
**GEOPY-1129 - remove python 3.9 from pytest-unix-os github action**
