### PR TITLE
GEOPY-1321: Change inheritance of ConcatenatedDrillholes

### DIFF
--- a/geoh5py/objects/drillhole.py
+++ b/geoh5py/objects/drillhole.py
@@ -593,23 +593,29 @@ class Drillhole(Points):
 
         return values
 
-    def validate_log_data(
+    def validate_depth_data(
         self,
         depth: np.ndarray,
-        input_values: np.ndarray,
+        values: np.ndarray,
         collocation_distance=1e-4,
     ) -> np.ndarray:
         """
         Compare new and current depth values. Append new vertices if necessary and return
         an augmented values vector that matches the vertices indexing.
+
+        :param depth: Array of depth values.
+        :param values: Array of values.
+        :param collocation_distance: Minimum collocation distance for matching.
+
+        :return: Augmented values vector that matches the vertices indexing.
         """
-        if depth.shape != input_values.shape:
+        if depth.shape != values.shape:
             raise ValueError(
                 f"Mismatch between input 'depth' shape{depth.shape} "
-                + f"and 'values' shape{input_values.shape}"
+                + f"and 'values' shape{values.shape}"
             )
 
-        input_values = np.r_[input_values]
+        input_values = np.r_[values]
 
         if self.depths is None:
             self.add_vertices(self.desurvey(depth))
@@ -665,7 +671,7 @@ class Drillhole(Points):
 
         if "depth" in attributes.keys():
             attributes["association"] = "VERTEX"
-            attributes["values"] = self.validate_log_data(
+            attributes["values"] = self.validate_depth_data(
                 attributes["depth"],
                 attributes["values"],
                 collocation_distance=collocation_distance,

--- a/geoh5py/shared/concatenation/concatenated.py
+++ b/geoh5py/shared/concatenation/concatenated.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-from abc import ABC
 from typing import TYPE_CHECKING
 
 from geoh5py.shared.entity import Entity
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
     from .concatenator import Concatenator
 
 
-class Concatenated(Entity, ABC):
+class Concatenated(Entity):
     """
     Base class modifier for concatenated objects and data.
     """

--- a/geoh5py/shared/concatenation/concatenator.py
+++ b/geoh5py/shared/concatenation/concatenator.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import uuid
 import warnings
-from abc import ABC
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -50,7 +49,7 @@ PROPERTY_KWARGS = {
 }
 
 
-class Concatenator(Group, ABC):  # pylint: disable=too-many-public-methods
+class Concatenator(Group):  # pylint: disable=too-many-public-methods
     """
     Class modifier for concatenation of objects and data.
     """

--- a/geoh5py/shared/concatenation/data.py
+++ b/geoh5py/shared/concatenation/data.py
@@ -17,9 +17,9 @@
 
 from __future__ import annotations
 
-from abc import ABC
 from typing import TYPE_CHECKING
 
+from ...data import Data
 from ..utils import as_str_if_uuid
 from .concatenated import Concatenated
 
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from .object import ConcatenatedObject
 
 
-class ConcatenatedData(Concatenated, ABC):
+class ConcatenatedData(Concatenated, Data):
     _parent: ConcatenatedObject
 
     def __init__(self, entity_type, **kwargs):

--- a/geoh5py/shared/concatenation/drillhole.py
+++ b/geoh5py/shared/concatenation/drillhole.py
@@ -22,13 +22,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from ...data import Data
+from ...objects import Drillhole
 from .object import ConcatenatedObject
 
 if TYPE_CHECKING:
     from .property_group import ConcatenatedPropertyGroup
 
 
-class ConcatenatedDrillhole(ConcatenatedObject):
+class ConcatenatedDrillhole(ConcatenatedObject, Drillhole):
     @property
     def depth_(self) -> list[Data]:
         obj_list = []
@@ -156,16 +157,16 @@ class ConcatenatedDrillhole(ConcatenatedObject):
         self,
         depth: list | np.ndarray | None,
         values: np.ndarray,
-        property_group: str | ConcatenatedPropertyGroup | None = None,
         collocation_distance: float | None = None,
+        property_group: str | ConcatenatedPropertyGroup | None = None,
     ) -> ConcatenatedPropertyGroup:
         """
         Compare new and current depth values and reuse the property group if possible.
 
         :param depth: Sampling depths.
         :param values: Data samples to depths.
-        :param property_group: Group for possibly collocated data.
         :param collocation_distance: Threshold on the comparison between existing depth values.
+        :param property_group: Group for possibly collocated data.
 
         :return: Augmented property group with name/values added for collocated data
             otherwise newly created property group with name/depth/values added.
@@ -244,8 +245,8 @@ class ConcatenatedDrillhole(ConcatenatedObject):
         self,
         from_to: list | np.ndarray | None,
         values: np.ndarray,
-        property_group: str | ConcatenatedPropertyGroup | None = None,
         collocation_distance=1e-4,
+        property_group: str | ConcatenatedPropertyGroup | None = None,
     ) -> ConcatenatedPropertyGroup:
         """
         Compare new and current depth values and reuse the property group if possible.
@@ -253,8 +254,8 @@ class ConcatenatedDrillhole(ConcatenatedObject):
 
         :param from_to: Array of from-to values.
         :param values: Data values to be added on the from-to intervals.
-        :param property_group: Property group name.
         :param collocation_distance: Threshold on the comparison between existing depth values.
+        :param property_group: Property group name.
 
         :return A ConcatenatedPropertyGroup with the matched values.
         """

--- a/geoh5py/shared/concatenation/drillhole.py
+++ b/geoh5py/shared/concatenation/drillhole.py
@@ -17,20 +17,18 @@
 
 from __future__ import annotations
 
-from abc import ABC
 from typing import TYPE_CHECKING
 
 import numpy as np
 
-from geoh5py.data import Data
-
+from ...data import Data
 from .object import ConcatenatedObject
 
 if TYPE_CHECKING:
     from .property_group import ConcatenatedPropertyGroup
 
 
-class ConcatenatedDrillhole(ConcatenatedObject, ABC):
+class ConcatenatedDrillhole(ConcatenatedObject):
     @property
     def depth_(self) -> list[Data]:
         obj_list = []

--- a/geoh5py/shared/concatenation/object.py
+++ b/geoh5py/shared/concatenation/object.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import uuid
 import warnings
-from abc import ABC
 from typing import TYPE_CHECKING
 
 from ...objects import ObjectBase
@@ -31,7 +30,7 @@ if TYPE_CHECKING:
     from .concatenator import Concatenator
 
 
-class ConcatenatedObject(Concatenated, ObjectBase, ABC):
+class ConcatenatedObject(Concatenated, ObjectBase):
     _parent: Concatenator
     _property_groups: list | None = None
 

--- a/geoh5py/workspace/workspace.py
+++ b/geoh5py/workspace/workspace.py
@@ -548,14 +548,13 @@ class Workspace(AbstractContextManager):
             ):
                 if self.version > 1.0:
                     if member in (DrillholeGroup, IntegratorDrillholeGroup):
+                        # todo: will change with DrillholeConcatenator soon
                         member = type("Concatenator" + name, (Concatenator, member), {})
                     elif member is Drillhole and isinstance(
                         entity_kwargs.get("parent"),
                         (DrillholeGroup, IntegratorDrillholeGroup),
                     ):
-                        member = type(
-                            "Concatenated" + name, (ConcatenatedDrillhole, member), {}
-                        )
+                        member = ConcatenatedDrillhole
 
                 entity_type = member.find_or_create_type(self, **entity_type_kwargs)
 


### PR DESCRIPTION
**GEOPY-1321 - Change inheritance of ConcatenatedDrillholes**
change concatenation classes inheritance

I added "Data" to ConcatenatedData
I added "Base Object" to "Object"

To incorporate Drillhole on "ConcatenatedDrillhole", some changes had to be done in Drillholes

Is Concatenator Shouldn't be a DrillholeGroup inherited class?
Or an abstartc class at least with drillhole group Concateantor somewhere?