### PR TITLE
GEOPY-1319: add_children consistency

### DIFF
--- a/geoh5py/data/data.py
+++ b/geoh5py/data/data.py
@@ -218,6 +218,12 @@ class Data(Entity):
     def primitive_type(cls) -> PrimitiveTypeEnum:
         ...
 
+    def add_children(self, children: list):
+        """
+        Alias not implemented from base Entity class.
+        """
+        raise NotImplementedError("Data entity cannot contain children.")
+
     def add_file(self, file: str):
         """
         Alias not implemented from base Entity class.

--- a/geoh5py/data/data.py
+++ b/geoh5py/data/data.py
@@ -150,16 +150,6 @@ class Data(Entity):
         )
 
     @property
-    def extent(self) -> np.ndarray | None:
-        """
-        Geography bounding box of the parent object.
-
-        :return: shape(2, 3) Bounding box defined by the bottom South-West and
-            top North-East coordinates.
-        """
-        return None
-
-    @property
     def n_values(self) -> int | None:
         """
         :obj:`int`: Number of expected data values based on
@@ -246,7 +236,9 @@ class Data(Entity):
     @classmethod
     @abstractmethod
     def primitive_type(cls) -> PrimitiveTypeEnum:
-        ...
+        """
+        Return the primitive type of the data.
+        """
 
     def mask_by_extent(
         self, extent: np.ndarray, inverse: bool = False

--- a/geoh5py/data/data.py
+++ b/geoh5py/data/data.py
@@ -67,7 +67,6 @@ class Data(Entity):
     def copy(
         self,
         parent=None,
-        copy_children: bool = True,
         clear_cache: bool = False,
         mask: np.ndarray | None = None,
         **kwargs,
@@ -77,7 +76,6 @@ class Data(Entity):
 
         :param parent: Target parent to copy the entity under. Copied to current
             :obj:`~geoh5py.shared.entity.Entity.parent` if None.
-        :param copy_children: (Optional) Create copies of all children entities along with it.
         :param clear_cache: Clear array attributes after copy.
         :param mask: Array of bool defining the values to keep.
         :param kwargs: Additional keyword arguments to pass to the copy constructor.
@@ -118,6 +116,38 @@ class Data(Entity):
         )
 
         return new_entity
+
+    def copy_from_extent(
+        self,
+        extent: np.ndarray,
+        parent=None,
+        clear_cache: bool = False,
+        inverse: bool = False,
+        **kwargs,
+    ) -> Entity | None:
+        """
+        Function to copy an entity to a different parent entity.
+
+        :param extent: Bounding box extent requested for the input entity, as supplied for
+            :func:`~geoh5py.shared.entity.Entity.mask_by_extent`.
+        :param parent: Target parent to copy the entity under. Copied to current
+            :obj:`~geoh5py.shared.entity.Entity.parent` if None.
+        :param clear_cache: Clear array attributes after copy.
+        :param inverse: Keep the inverse (clip) of the extent selection.
+        :param kwargs: Additional keyword arguments to pass to the copy constructor.
+
+        :return entity: Registered Entity to the workspace.
+        """
+        indices = self.mask_by_extent(extent, inverse=inverse)
+        if indices is None:
+            return None
+
+        return self.copy(
+            parent=parent,
+            clear_cache=clear_cache,
+            mask=indices,
+            **kwargs,
+        )
 
     @property
     def extent(self) -> np.ndarray | None:
@@ -217,18 +247,6 @@ class Data(Entity):
     @abstractmethod
     def primitive_type(cls) -> PrimitiveTypeEnum:
         ...
-
-    def add_children(self, children: list):
-        """
-        Alias not implemented from base Entity class.
-        """
-        raise NotImplementedError("Data entity cannot contain children.")
-
-    def add_file(self, file: str):
-        """
-        Alias not implemented from base Entity class.
-        """
-        raise NotImplementedError("Data entity cannot contain files.")
 
     def mask_by_extent(
         self, extent: np.ndarray, inverse: bool = False

--- a/geoh5py/data/data.py
+++ b/geoh5py/data/data.py
@@ -62,8 +62,6 @@ class Data(Entity):
         if self.entity_type.name == "Entity":
             self.entity_type.name = self.name
 
-        getattr(data_type.workspace, "_register_data")(self)
-
     def copy(
         self,
         parent=None,

--- a/geoh5py/data/data.py
+++ b/geoh5py/data/data.py
@@ -124,7 +124,7 @@ class Data(Entity):
         **kwargs,
     ) -> Entity | None:
         """
-        Function to copy an entity to a different parent entity.
+        Function to copy data based on a bounding box extent.
 
         :param extent: Bounding box extent requested for the input entity, as supplied for
             :func:`~geoh5py.shared.entity.Entity.mask_by_extent`.

--- a/geoh5py/data/data_type.py
+++ b/geoh5py/data/data_type.py
@@ -62,8 +62,6 @@ class DataType(EntityType):
         assert workspace is not None
         super().__init__(workspace, **kwargs)
 
-        workspace._register_type(self)
-
     @staticmethod
     def _is_abstract() -> bool:
         return False

--- a/geoh5py/groups/container_group.py
+++ b/geoh5py/groups/container_group.py
@@ -39,8 +39,6 @@ class ContainerGroup(Group):
         if self.entity_type.name == "Entity":
             self.entity_type.name = "Container Group"
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID

--- a/geoh5py/groups/custom_group.py
+++ b/geoh5py/groups/custom_group.py
@@ -35,8 +35,6 @@ class CustomGroup(Group):
         if self.entity_type.name == "Entity":
             self.entity_type.name = "Custom Group"
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID | None:
         # raise RuntimeError(f"No predefined static type UUID for {cls}.")

--- a/geoh5py/groups/drillhole_group.py
+++ b/geoh5py/groups/drillhole_group.py
@@ -36,8 +36,6 @@ class DrillholeGroup(Group):
         if self.entity_type.name == "Entity":
             self.entity_type.name = name
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID

--- a/geoh5py/groups/giftools_group.py
+++ b/geoh5py/groups/giftools_group.py
@@ -39,8 +39,6 @@ class GiftoolsGroup(Group):
         if self.entity_type.name == "Entity":
             self.entity_type.name = "GIFtools Group"
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID

--- a/geoh5py/groups/group.py
+++ b/geoh5py/groups/group.py
@@ -25,14 +25,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from ..data import CommentsData, Data
-from ..shared import Entity
+from ..shared.entity_container import EntityContainer
 from .group_type import GroupType
 
 if TYPE_CHECKING:
     from .. import workspace
 
 
-class Group(Entity):
+class Group(EntityContainer):
     """Base Group class"""
 
     def __init__(self, group_type: GroupType, **kwargs):

--- a/geoh5py/groups/group.py
+++ b/geoh5py/groups/group.py
@@ -78,7 +78,6 @@ class Group(EntityContainer):
         """
         Sub-class extension of :func:`~geoh5py.shared.entity.Entity.mask_by_extent`.
         """
-
         return None
 
     def copy(

--- a/geoh5py/groups/group.py
+++ b/geoh5py/groups/group.py
@@ -45,22 +45,6 @@ class Group(Entity):
     def default_type_uid(cls) -> uuid.UUID | None:
         ...
 
-    def add_children(self, children: list[Entity]):
-        """
-        :param children: Add a list of entities as
-            :obj:`~geoh5py.shared.entity.Entity.children`
-        """
-        if not isinstance(children, list):
-            children = [children]
-
-        for child in children:
-            if child not in self._children:
-                if not isinstance(child, Entity):
-                    raise TypeError(
-                        f"Child must be an instance of Entity, not {type(child)}"
-                    )
-                self._children.append(child)
-
     def add_comment(self, comment: str, author: str | None = None):
         """
         Add text comment to an object.

--- a/geoh5py/groups/group.py
+++ b/geoh5py/groups/group.py
@@ -45,6 +45,22 @@ class Group(Entity):
     def default_type_uid(cls) -> uuid.UUID | None:
         ...
 
+    def add_children(self, children: list[Entity]):
+        """
+        :param children: Add a list of entities as
+            :obj:`~geoh5py.shared.entity.Entity.children`
+        """
+        if not isinstance(children, list):
+            children = [children]
+
+        for child in children:
+            if child not in self._children:
+                if not isinstance(child, Entity):
+                    raise TypeError(
+                        f"Child must be an instance of Entity, not {type(child)}"
+                    )
+                self._children.append(child)
+
     def add_comment(self, comment: str, author: str | None = None):
         """
         Add text comment to an object.

--- a/geoh5py/groups/group_type.py
+++ b/geoh5py/groups/group_type.py
@@ -43,8 +43,6 @@ class GroupType(EntityType):
         assert workspace is not None
         super().__init__(workspace, **kwargs)
 
-        workspace._register_type(self)
-
     @staticmethod
     def _is_abstract() -> bool:
         return False

--- a/geoh5py/groups/integrator_group.py
+++ b/geoh5py/groups/integrator_group.py
@@ -34,8 +34,6 @@ class AirborneTheme(Group):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID
@@ -52,8 +50,6 @@ class EarthModelsTheme(Group):
     def __init__(self, group_type: GroupType, **kwargs):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
-
-        group_type.workspace._register_group(self)
 
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
@@ -72,8 +68,6 @@ class GeochemistryMineralogyTheme(Group):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID
@@ -90,8 +84,6 @@ class GeochemistryMineralogyDataSet(Group):
     def __init__(self, group_type: GroupType, **kwargs):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
-
-        group_type.workspace._register_group(self)
 
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
@@ -110,8 +102,6 @@ class GeophysicsTheme(Group):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID
@@ -128,8 +118,6 @@ class GroundTheme(Group):
     def __init__(self, group_type: GroupType, **kwargs):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
-
-        group_type.workspace._register_group(self)
 
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
@@ -148,8 +136,6 @@ class IntegratorProject(Group):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID
@@ -166,8 +152,6 @@ class IntegratorGroup(Group):
     def __init__(self, group_type: GroupType, **kwargs):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
-
-        group_type.workspace._register_group(self)
 
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
@@ -186,8 +170,6 @@ class QueryGroup(Group):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID
@@ -204,8 +186,6 @@ class ObservationPointsTheme(Group):
     def __init__(self, group_type: GroupType, **kwargs):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
-
-        group_type.workspace._register_group(self)
 
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
@@ -224,8 +204,6 @@ class RockPropertiesTheme(Group):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID
@@ -242,8 +220,6 @@ class SamplesTheme(Group):
     def __init__(self, group_type: GroupType, **kwargs):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
-
-        group_type.workspace._register_group(self)
 
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:

--- a/geoh5py/groups/maps_group.py
+++ b/geoh5py/groups/maps_group.py
@@ -34,8 +34,6 @@ class MapsGroup(Group):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID

--- a/geoh5py/groups/notype_group.py
+++ b/geoh5py/groups/notype_group.py
@@ -39,8 +39,6 @@ class NoTypeGroup(Group):
         if self.entity_type.name == "Entity":
             self.entity_type.name = "NoType Group"
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID

--- a/geoh5py/groups/property_group.py
+++ b/geoh5py/groups/property_group.py
@@ -26,7 +26,6 @@ from geoh5py.data import Data, DataAssociationEnum
 
 if TYPE_CHECKING:
     from geoh5py.objects import ObjectBase
-    from geoh5py.shared import Entity
 
 
 class PropertyGroup(ABC):
@@ -183,7 +182,7 @@ class PropertyGroup(ABC):
         self._on_file = value
 
     @property
-    def parent(self) -> Entity:
+    def parent(self) -> ObjectBase:
         """
         The parent :obj:`~geoh5py.objects.object_base.ObjectBase`
         """

--- a/geoh5py/groups/property_group.py
+++ b/geoh5py/groups/property_group.py
@@ -78,7 +78,7 @@ class PropertyGroup(ABC):
             except AttributeError:
                 continue
 
-        self.parent.workspace.register_property_group(self)
+        self.parent.workspace.register(self)
 
     def add_properties(self, data: Data | list[Data | uuid.UUID] | uuid.UUID):
         """

--- a/geoh5py/groups/simpeg_group.py
+++ b/geoh5py/groups/simpeg_group.py
@@ -37,8 +37,6 @@ class SimPEGGroup(Group):
         if self.entity_type.name == "Entity":
             self.entity_type.name = "SimPEG"
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID

--- a/geoh5py/groups/survey_group.py
+++ b/geoh5py/groups/survey_group.py
@@ -34,8 +34,6 @@ class AirborneGeophysics(Group):
         assert group_type is not None
         super().__init__(group_type, **kwargs)
 
-        group_type.workspace._register_group(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID

--- a/geoh5py/io/h5_writer.py
+++ b/geoh5py/io/h5_writer.py
@@ -230,7 +230,11 @@ class H5Writer:
         with fetch_h5_handle(file, mode="r+") as h5file:
             new_entity = H5Writer.write_entity(h5file, entity, compression)
 
-            if add_children and not isinstance(entity, Concatenator):
+            if (
+                add_children
+                and not isinstance(entity, Concatenator)
+                and hasattr(entity, "children")
+            ):
                 # Write children entities and add to current parent
                 for child in entity.children:
                     if not isinstance(child, PropertyGroup):

--- a/geoh5py/objects/block_model.py
+++ b/geoh5py/objects/block_model.py
@@ -52,8 +52,6 @@ class BlockModel(GridObject):
 
         super().__init__(object_type, **kwargs)
 
-        object_type.workspace._register_object(self)
-
     @property
     def centroids(self) -> np.ndarray | None:
         """

--- a/geoh5py/objects/drape_model.py
+++ b/geoh5py/objects/drape_model.py
@@ -38,8 +38,6 @@ class DrapeModel(GridObject):
 
         super().__init__(object_type, **kwargs)
 
-        object_type.workspace._register_object(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID

--- a/geoh5py/objects/geo_image.py
+++ b/geoh5py/objects/geo_image.py
@@ -62,8 +62,6 @@ class GeoImage(ObjectBase):
 
         super().__init__(object_type, **kwargs)
 
-        object_type.workspace._register_object(self)
-
     @property
     def cells(self) -> np.ndarray | None:
         r"""

--- a/geoh5py/objects/grid2d.py
+++ b/geoh5py/objects/grid2d.py
@@ -72,8 +72,6 @@ class Grid2D(GridObject):
 
         super().__init__(object_type, **kwargs)
 
-        object_type.workspace._register_object(self)
-
     @property
     def cell_center_u(self) -> np.ndarray | None:
         """

--- a/geoh5py/objects/label.py
+++ b/geoh5py/objects/label.py
@@ -46,8 +46,6 @@ class Label(ObjectBase):
 
         super().__init__(object_type, **kwargs)
 
-        object_type.workspace._register_object(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID

--- a/geoh5py/objects/notype_object.py
+++ b/geoh5py/objects/notype_object.py
@@ -22,7 +22,6 @@ import warnings
 from typing import TYPE_CHECKING
 
 from .object_base import ObjectBase
-from .object_type import ObjectType
 
 if TYPE_CHECKING:
     from numpy import ndarray
@@ -36,11 +35,6 @@ class NoTypeObject(ObjectBase):
     __TYPE_UID = uuid.UUID(
         fields=(0x849D2F3E, 0xA46E, 0x11E3, 0xB4, 0x01, 0x2776BDF4F982)
     )
-
-    def __init__(self, object_type: ObjectType, **kwargs):
-        super().__init__(object_type, **kwargs)
-
-        object_type.workspace._register_object(self)
 
     def copy(
         self,

--- a/geoh5py/objects/object_base.py
+++ b/geoh5py/objects/object_base.py
@@ -57,7 +57,6 @@ class ObjectBase(EntityContainer):
         self._entity_type = object_type
         self._last_focus = "None"
         self._property_groups: list[PropertyGroup] | None = None
-        # self._clipping_ids: list[uuid.UUID] = []
         self._visual_parameters: VisualParameters | None = None
 
         if not any(key for key in kwargs if key in ["name", "Name"]):

--- a/geoh5py/objects/object_base.py
+++ b/geoh5py/objects/object_base.py
@@ -32,6 +32,7 @@ from ..data.primitive_type_enum import PrimitiveTypeEnum
 from ..groups import PropertyGroup
 from ..shared import Entity, EntityType
 from ..shared.conversion import BaseConversion
+from ..shared.entity_container import EntityContainer
 from ..shared.utils import clear_array_attributes
 from .object_type import ObjectType
 
@@ -39,12 +40,12 @@ if TYPE_CHECKING:
     from .. import workspace
 
 
-class ObjectBase(Entity):
+class ObjectBase(EntityContainer):
     """
     Object base class.
     """
 
-    _attribute_map: dict = Entity._attribute_map.copy()
+    _attribute_map: dict = getattr(EntityContainer, "_attribute_map").copy()
     _attribute_map.update(
         {"Last focus": "last_focus", "PropertyGroups": "property_groups"}
     )

--- a/geoh5py/objects/object_type.py
+++ b/geoh5py/objects/object_type.py
@@ -35,8 +35,6 @@ class ObjectType(EntityType):
         assert workspace is not None
         super().__init__(workspace, **kwargs)
 
-        workspace._register_type(self)
-
     @staticmethod
     def _is_abstract() -> bool:
         return False

--- a/geoh5py/objects/octree.py
+++ b/geoh5py/objects/octree.py
@@ -65,8 +65,6 @@ class Octree(GridObject):
 
         super().__init__(object_type, **kwargs)
 
-        object_type.workspace._register_object(self)
-
     def base_refine(self):
         """
         Refine the mesh to its base octree level resulting in a

--- a/geoh5py/objects/points.py
+++ b/geoh5py/objects/points.py
@@ -38,8 +38,6 @@ class Points(ObjectBase):
 
         super().__init__(object_type, name=name, **kwargs)
 
-        object_type.workspace._register_object(self)
-
     @classmethod
     def default_type_uid(cls) -> uuid.UUID:
         return cls.__TYPE_UID

--- a/geoh5py/shared/concatenation/concatenated.py
+++ b/geoh5py/shared/concatenation/concatenated.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from geoh5py.shared.entity import Entity
+from ...shared.entity import Entity
 
 if TYPE_CHECKING:
     from .concatenator import Concatenator

--- a/geoh5py/shared/entity.py
+++ b/geoh5py/shared/entity.py
@@ -81,13 +81,20 @@ class Entity(ABC):
             except AttributeError:
                 continue
 
-    def add_children(self, children: list[shared.Entity]):
+    def add_children(self, children: list[Entity]):
         """
         :param children: Add a list of entities as
             :obj:`~geoh5py.shared.entity.Entity.children`
         """
+        if not isinstance(children, list):
+            children = [children]
+
         for child in children:
             if child not in self._children:
+                if not isinstance(child, Entity):
+                    raise TypeError(
+                        f"Child must be an instance of Entity, not {type(child)}"
+                    )
                 self._children.append(child)
 
     def add_file(self, file: str):
@@ -411,7 +418,7 @@ class Entity(ABC):
     def parent(self, parent: shared.Entity):
         current_parent = self._parent
 
-        if parent is not None:
+        if hasattr(parent, "add_children"):
             parent.add_children([self])
             self._parent = parent
 

--- a/geoh5py/shared/entity.py
+++ b/geoh5py/shared/entity.py
@@ -20,9 +20,7 @@
 from __future__ import annotations
 
 import uuid
-import warnings
 from abc import ABC, abstractmethod
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -30,10 +28,7 @@ import numpy as np
 from geoh5py.shared.utils import str2uuid
 
 if TYPE_CHECKING:
-    from numpy import ndarray
-
     from .. import shared
-    from ..groups import PropertyGroup
     from ..workspace import Workspace
 
 DEFAULT_CRS = {"Code": "Unknown", "Name": "Unknown"}
@@ -61,17 +56,17 @@ class Entity(ABC):
         self._uid = (
             str2uuid(uid) if isinstance(str2uuid(uid), uuid.UUID) else uuid.uuid4()
         )
-        self._name = name
-        self._parent: Entity | None = None
-        self._children: list = []
+
         self._allow_delete = True
         self._allow_move = True
         self._allow_rename = True
-        self._partially_hidden = False
         self._clipping_ids: list[uuid.UUID] | None = None
-        self._public = True
-        self._on_file = False
         self._metadata: dict | None = None
+        self._name = name
+        self._on_file = False
+        self._parent: Entity | None = None
+        self._partially_hidden = False
+        self._public = True
 
         for attr, item in kwargs.items():
             try:
@@ -80,50 +75,6 @@ class Entity(ABC):
                 setattr(self, attr, item)
             except AttributeError:
                 continue
-
-    def add_children(self, children: list[Entity]):
-        """
-        :param children: Add a list of entities as
-            :obj:`~geoh5py.shared.entity.Entity.children`
-        """
-        if not isinstance(children, list):
-            children = [children]
-
-        for child in children:
-            if child not in self._children:
-                if not isinstance(child, Entity):
-                    raise TypeError(
-                        f"Child must be an instance of Entity, not {type(child)}"
-                    )
-                self._children.append(child)
-
-    def add_file(self, file: str):
-        """
-        Add a file to the object or group stored as bytes on a FilenameData
-
-        :param file: File name with path to import.
-        """
-        if not Path(file).is_file():
-            raise ValueError(f"Input file '{file}' does not exist.")
-
-        with open(file, "rb") as raw_binary:
-            blob = raw_binary.read()
-
-        name = Path(file).name
-        attributes = {
-            "name": name,
-            "file_name": name,
-            "association": "OBJECT",
-            "parent": self,
-            "values": blob,
-        }
-        entity_type = {"name": "UserFiles", "primitive_type": "FILENAME"}
-
-        file_data = self.workspace.create_entity(
-            None, entity=attributes, entity_type=entity_type
-        )
-
-        return file_data
 
     @property
     def allow_delete(self) -> bool:
@@ -170,58 +121,11 @@ class Entity(ABC):
         return self._attribute_map
 
     @property
-    def children(self):
-        """
-        :obj:`list` Children entities in the workspace tree
-        """
-        return self._children
-
-    @property
     def clipping_ids(self) -> list[uuid.UUID] | None:
         """
         List of clipping uuids
         """
         return self._clipping_ids
-
-    @abstractmethod
-    def mask_by_extent(
-        self, extent: np.ndarray, inverse: bool = False
-    ) -> np.ndarray | None:
-        """
-        Get a mask array from coordinate extent.
-
-        :param extent: Bounding box extent coordinates defined by either:
-            - obj:`numpy.ndarray` of shape (2, 3)
-            3D coordinate: [[west, south, bottom], [east, north, top]]
-            - obj:`numpy.ndarray` of shape (2, 2)
-            Horizontal coordinates: [[west, south], [east, north]].
-        :param inverse: Return the complement of the mask extent. Default to False
-
-        :return: Array of bool defining the vertices or cell centers
-            within the mask extent, or None if no intersection.
-        """
-
-    @classmethod
-    def create(cls, workspace, **kwargs):
-        """
-        Function to create an entity.
-
-        :param workspace: Workspace to be added to.
-        :param kwargs: List of keyword arguments defining the properties of a class.
-
-        :return entity: Registered Entity to the workspace.
-        """
-        entity_type_kwargs = (
-            {"entity_type": {"uid": kwargs["entity_type_uid"]}}
-            if "entity_type_uid" in kwargs
-            else {}
-        )
-        entity_kwargs = {"entity": kwargs}
-        new_object = workspace.create_entity(
-            cls,
-            **{**entity_kwargs, **entity_type_kwargs},
-        )
-        return new_object
 
     @property
     def coordinate_reference_system(self) -> dict:
@@ -263,63 +167,27 @@ class Entity(ABC):
 
         self.metadata = metadata
 
-    @abstractmethod
-    def copy(
-        self,
-        parent=None,
-        copy_children: bool = True,
-        clear_cache: bool = False,
-        mask: np.ndarray | None = None,
-        **kwargs,
-    ):
+    @classmethod
+    def create(cls, workspace, **kwargs):
         """
-        Function to copy an entity to a different parent entity.
+        Function to create an entity.
 
-        :param parent: Target parent to copy the entity under. Copied to current
-            :obj:`~geoh5py.shared.entity.Entity.parent` if None.
-        :param copy_children: (Optional) Create copies of all children entities along with it.
-        :param clear_cache: Clear array attributes after copy to minimize the
-            memory footprint of the workspace.
-        :param mask: Array of indices to sub-sample the input entity.
-        :param kwargs: Additional keyword arguments to pass to the copy constructor.
+        :param workspace: Workspace to be added to.
+        :param kwargs: List of keyword arguments defining the properties of a class.
 
         :return entity: Registered Entity to the workspace.
         """
-
-    def copy_from_extent(
-        self,
-        extent: ndarray,
-        parent=None,
-        copy_children: bool = True,
-        clear_cache: bool = False,
-        inverse: bool = False,
-        **kwargs,
-    ) -> Entity | None:
-        """
-        Function to copy an entity to a different parent entity.
-
-        :param extent: Bounding box extent requested for the input entity, as supplied for
-            :func:`~geoh5py.shared.entity.Entity.mask_by_extent`.
-        :param parent: Target parent to copy the entity under. Copied to current
-            :obj:`~geoh5py.shared.entity.Entity.parent` if None.
-        :param copy_children: (Optional) Create copies of all children entities along with it.
-        :param clear_cache: Clear array attributes after copy.
-        :param inverse: Keep the inverse (clip) of the extent selection.
-        :param kwargs: Additional keyword arguments to pass to the copy constructor.
-
-        :return entity: Registered Entity to the workspace.
-        """
-        indices = self.mask_by_extent(extent, inverse=inverse)
-        if indices is None:
-            return None
-
-        return self.copy(
-            parent=parent,
-            copy_children=copy_children,
-            clear_cache=clear_cache,
-            mask=indices,
-            **kwargs,
+        entity_type_kwargs = (
+            {"entity_type": {"uid": kwargs["entity_type_uid"]}}
+            if "entity_type_uid" in kwargs
+            else {}
         )
+        entity_kwargs = {"entity": kwargs}
+        new_object = workspace.create_entity(
+            cls,
+            **{**entity_kwargs, **entity_type_kwargs},
+        )
+        return new_object
 
     @property
     @abstractmethod
@@ -336,36 +204,23 @@ class Entity(ABC):
         #  (possibly it has to be abstract with different implementations per Entity type)
         return name
 
-    def get_entity(self, name: str | uuid.UUID) -> list[Entity | None]:
+    @abstractmethod
+    def mask_by_extent(
+        self, extent: np.ndarray, inverse: bool = False
+    ) -> np.ndarray | None:
         """
-        Get a child :obj:`~geoh5py.data.data.Data` by name.
+        Get a mask array from coordinate extent.
 
-        :param name: Name of the target child data
-        :param entity_type: Sub-select entities based on type.
-        :return: A list of children Data objects
+        :param extent: Bounding box extent coordinates defined by either:
+            - obj:`numpy.ndarray` of shape (2, 3)
+            3D coordinate: [[west, south, bottom], [east, north, top]]
+            - obj:`numpy.ndarray` of shape (2, 2)
+            Horizontal coordinates: [[west, south], [east, north]].
+        :param inverse: Return the complement of the mask extent. Default to False
+
+        :return: Array of bool defining the vertices or cell centers
+            within the mask extent, or None if no intersection.
         """
-
-        if isinstance(name, uuid.UUID):
-            entity_list = [child for child in self.children if child.uid == name]
-        else:
-            entity_list = [child for child in self.children if child.name == name]
-
-        if not entity_list:
-            return [None]
-
-        return entity_list
-
-    def get_entity_list(self, entity_type=ABC) -> list[str]:
-        """
-        Get a list of names of all children :obj:`~geoh5py.data.data.Data`.
-
-        :param entity_type: Option to sub-select based on type.
-        :return: List of names of data associated with the object.
-        """
-        name_list = [
-            child.name for child in self.children if isinstance(child, entity_type)
-        ]
-        return sorted(name_list)
 
     @property
     def metadata(self) -> dict | None:
@@ -418,11 +273,15 @@ class Entity(ABC):
     def parent(self, parent: shared.Entity):
         current_parent = self._parent
 
-        if hasattr(parent, "add_children"):
+        if hasattr(parent, "add_children") and hasattr(parent, "remove_children"):
             parent.add_children([self])
             self._parent = parent
 
-            if current_parent is not None and current_parent != self._parent:
+            if (
+                current_parent is not None
+                and current_parent != self._parent
+                and hasattr(current_parent, "remove_children")
+            ):
                 current_parent.remove_children([self])
                 self.workspace.save_entity(self)
 
@@ -450,60 +309,6 @@ class Entity(ABC):
     def public(self, value: bool):
         self._public = value
         self.workspace.update_attribute(self, "attributes")
-
-    def reference_to_uid(
-        self, value: Entity | PropertyGroup | str | uuid.UUID
-    ) -> list[uuid.UUID]:
-        """
-        General entity reference translation.
-
-        :param value: Either an `Entity`, string or uuid
-
-        :return: List of unique identifier associated with the input reference.
-        """
-        children_uid = [child.uid for child in self.children]
-        if hasattr(value, "uid"):
-            uid = [value.uid]
-        elif isinstance(value, str):
-            uid = [
-                obj.uid
-                for obj in self.workspace.get_entity(value)
-                if (obj is not None) and (obj.uid in children_uid)
-            ]
-        elif isinstance(value, uuid.UUID):
-            uid = [value]
-
-        return uid
-
-    def remove_children(self, children: list[shared.Entity] | list[PropertyGroup]):
-        """
-        Remove children from the list of children entities.
-
-        :param children: List of entities
-
-        .. warning::
-            Removing a child entity without re-assigning it to a different
-            parent may cause it to become inactive. Inactive entities are removed
-            from the workspace by
-            :func:`~geoh5py.shared.weakref_utils.remove_none_referents`.
-        """
-        if not isinstance(children, list):
-            children = [children]
-
-        self._children = [child for child in self._children if child not in children]
-        self.workspace.remove_children(self, children)
-
-    def save(self, add_children: bool = True):
-        """
-        Alias method of :func:`~geoh5py.workspace.Workspace.save_entity`.
-        WILL BE DEPRECATED AS ENTITIES ARE ALWAYS AUTOMATICALLY UPDATED.
-        :param add_children: Option to also save the children.
-        """
-        warnings.warn(
-            "Entity.save() is deprecated and will be removed in next versions.",
-            DeprecationWarning,
-        )
-        return self.workspace.save_entity(self, add_children=add_children)
 
     @property
     def uid(self) -> uuid.UUID:

--- a/geoh5py/shared/entity.py
+++ b/geoh5py/shared/entity.py
@@ -76,6 +76,8 @@ class Entity(ABC):
             except AttributeError:
                 continue
 
+        self.workspace.register(self)
+
     @property
     def allow_delete(self) -> bool:
         """

--- a/geoh5py/shared/entity_container.py
+++ b/geoh5py/shared/entity_container.py
@@ -196,7 +196,7 @@ class EntityContainer(Entity):
         """
         General entity reference translation.
 
-        Todo: Remove in future release:
+        Todo: Remove in future release
 
         :param value: Either an `Entity`, string or uuid
 

--- a/geoh5py/shared/entity_container.py
+++ b/geoh5py/shared/entity_container.py
@@ -1,0 +1,241 @@
+#  Copyright (c) 2024 Mira Geoscience Ltd.
+#
+#  This file is part of geoh5py.
+#
+#  geoh5py is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  geoh5py is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
+
+# pylint: disable=R0904
+
+from __future__ import annotations
+
+import uuid
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING
+from warnings import warn
+
+import numpy as np
+
+from ..shared.utils import str2uuid
+from .entity import Entity
+
+if TYPE_CHECKING:
+    from .. import shared
+    from ..groups import PropertyGroup
+
+DEFAULT_CRS = {"Code": "Unknown", "Name": "Unknown"}
+
+
+class EntityContainer(Entity):
+    """
+    Base Entity class
+    """
+
+    def __init__(self, uid: uuid.UUID | None = None, name="Entity", **kwargs):
+        self._uid = (
+            str2uuid(uid) if isinstance(str2uuid(uid), uuid.UUID) else uuid.uuid4()
+        )
+        self._children: list = []
+
+        super().__init__(uid, name, **kwargs)
+
+    def add_children(self, children: list[Entity]):
+        """
+        :param children: Add a list of entities as
+            :obj:`~geoh5py.shared.entity.Entity.children`
+        """
+        if not isinstance(children, list):
+            children = [children]
+
+        for child in children:
+            if child not in self._children:
+                if not isinstance(child, Entity):
+                    raise TypeError(
+                        f"Child must be an instance of Entity, not {type(child)}"
+                    )
+                self._children.append(child)
+
+    def add_file(self, file: str):
+        """
+        Add a file to the object or group stored as bytes on a FilenameData
+
+        :param file: File name with path to import.
+        """
+        if not Path(file).is_file():
+            raise ValueError(f"Input file '{file}' does not exist.")
+
+        with open(file, "rb") as raw_binary:
+            blob = raw_binary.read()
+
+        name = Path(file).name
+        attributes = {
+            "name": name,
+            "file_name": name,
+            "association": "OBJECT",
+            "parent": self,
+            "values": blob,
+        }
+        entity_type = {"name": "UserFiles", "primitive_type": "FILENAME"}
+
+        file_data = self.workspace.create_entity(
+            None, entity=attributes, entity_type=entity_type
+        )
+
+        return file_data
+
+    @property
+    def children(self):
+        """
+        :obj:`list` Children entities in the workspace tree
+        """
+        return self._children
+
+    @abstractmethod
+    def copy(
+        self,
+        parent=None,
+        copy_children: bool = True,
+        clear_cache: bool = False,
+        mask: np.ndarray | None = None,
+        **kwargs,
+    ):
+        """
+        Function to copy an entity to a different parent entity.
+
+        :param parent: Target parent to copy the entity under. Copied to current
+            :obj:`~geoh5py.shared.entity.Entity.parent` if None.
+        :param copy_children: (Optional) Create copies of all children entities along with it.
+        :param clear_cache: Clear array attributes after copy to minimize the
+            memory footprint of the workspace.
+        :param mask: Array of indices to sub-sample the input entity.
+        :param kwargs: Additional keyword arguments to pass to the copy constructor.
+
+        :return entity: Registered Entity to the workspace.
+        """
+
+    def copy_from_extent(
+        self,
+        extent: np.ndarray,
+        parent=None,
+        copy_children: bool = True,
+        clear_cache: bool = False,
+        inverse: bool = False,
+        **kwargs,
+    ) -> Entity | None:
+        """
+        Function to copy an entity to a different parent entity.
+
+        :param extent: Bounding box extent requested for the input entity, as supplied for
+            :func:`~geoh5py.shared.entity.Entity.mask_by_extent`.
+        :param parent: Target parent to copy the entity under. Copied to current
+            :obj:`~geoh5py.shared.entity.Entity.parent` if None.
+        :param copy_children: (Optional) Create copies of all children entities along with it.
+        :param clear_cache: Clear array attributes after copy.
+        :param inverse: Keep the inverse (clip) of the extent selection.
+        :param kwargs: Additional keyword arguments to pass to the copy constructor.
+
+        :return entity: Registered Entity to the workspace.
+        """
+        indices = self.mask_by_extent(extent, inverse=inverse)
+        if indices is None:
+            return None
+
+        return self.copy(
+            parent=parent,
+            copy_children=copy_children,
+            clear_cache=clear_cache,
+            mask=indices,
+            **kwargs,
+        )
+
+    def get_entity(self, name: str | uuid.UUID) -> list[Entity | None]:
+        """
+        Get a child :obj:`~geoh5py.data.data.Data` by name.
+
+        :param name: Name of the target child data
+        :param entity_type: Sub-select entities based on type.
+        :return: A list of children Data objects
+        """
+
+        if isinstance(name, uuid.UUID):
+            entity_list = [child for child in self.children if child.uid == name]
+        else:
+            entity_list = [child for child in self.children if child.name == name]
+
+        if not entity_list:
+            return [None]
+
+        return entity_list
+
+    def get_entity_list(self, entity_type=ABC) -> list[str]:
+        """
+        Get a list of names of all children :obj:`~geoh5py.data.data.Data`.
+
+        :param entity_type: Option to sub-select based on type.
+        :return: List of names of data associated with the object.
+        """
+        name_list = [
+            child.name for child in self.children if isinstance(child, entity_type)
+        ]
+        return sorted(name_list)
+
+    def reference_to_uid(
+        self, value: Entity | PropertyGroup | str | uuid.UUID
+    ) -> list[uuid.UUID]:
+        """
+        General entity reference translation.
+
+        Todo: Remove in future release:
+
+        :param value: Either an `Entity`, string or uuid
+
+        :return: List of unique identifier associated with the input reference.
+        """
+        warn(
+            "EntityContainer.reference_to_uid() is deprecated "
+            "and will be removed in versions 0.10.0.",
+            DeprecationWarning,
+        )
+
+        children_uid = [child.uid for child in self.children]
+        if hasattr(value, "uid"):
+            uid = [value.uid]
+        elif isinstance(value, str):
+            uid = [
+                obj.uid
+                for obj in self.workspace.get_entity(value)
+                if (obj is not None) and (obj.uid in children_uid)
+            ]
+        elif isinstance(value, uuid.UUID):
+            uid = [value]
+
+        return uid
+
+    def remove_children(self, children: list[shared.Entity] | list[PropertyGroup]):
+        """
+        Remove children from the list of children entities.
+
+        :param children: List of entities
+
+        .. warning::
+            Removing a child entity without re-assigning it to a different
+            parent may cause it to become inactive. Inactive entities are removed
+            from the workspace by
+            :func:`~geoh5py.shared.weakref_utils.remove_none_referents`.
+        """
+        if not isinstance(children, list):
+            children = [children]
+
+        self._children = [child for child in self._children if child not in children]
+        self.workspace.remove_children(self, children)

--- a/geoh5py/shared/entity_type.py
+++ b/geoh5py/shared/entity_type.py
@@ -50,6 +50,8 @@ class EntityType(ABC):
             except AttributeError:
                 continue
 
+        self.workspace.register(self)
+
     @property
     def attribute_map(self):
         """

--- a/geoh5py/shared/utils.py
+++ b/geoh5py/shared/utils.py
@@ -234,7 +234,7 @@ def clear_array_attributes(entity: Entity, recursive: bool = False):
         if hasattr(entity, attribute):
             setattr(entity, f"_{attribute}", None)
 
-    if recursive:
+    if recursive and hasattr(entity, "children"):
         for child in entity.children:
             clear_array_attributes(child, recursive=recursive)
 

--- a/tests/add_filename_data_test.py
+++ b/tests/add_filename_data_test.py
@@ -23,7 +23,6 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from geoh5py.data import Data
 from geoh5py.groups import ContainerGroup
 from geoh5py.objects import Curve
 from geoh5py.shared.utils import compare_entities
@@ -35,20 +34,12 @@ def test_add_file(tmp_path: Path):
     workspace_copy = Workspace()
     curve = Curve.create(workspace)
     group = ContainerGroup.create(workspace)
-    data = curve.add_data({"ABC": {"values": "axs"}})
 
     xyz = np.random.randn(32)
     np.savetxt(tmp_path / r"numpy_array.txt", xyz)
     file_name = "numpy_array.txt"
-    for obj in [data, curve, group]:
-        try:
-            file_data = obj.add_file(tmp_path / file_name)
-        except NotImplementedError:
-            assert isinstance(
-                obj, Data
-            ), "Only Data should return 'NotImplementedError'"
-            continue
-
+    for obj in [curve, group]:
+        file_data = obj.add_file(tmp_path / file_name)
         assert file_data.file_name == file_name, "File_name not properly set."
         assert file_data.n_values == 1, "Object association should have 1 value."
         # Rename the file locally and write back out

--- a/tests/data_instantiation_test.py
+++ b/tests/data_instantiation_test.py
@@ -24,7 +24,7 @@ import pytest
 
 from geoh5py import data
 from geoh5py.data import Data, DataAssociationEnum, DataType, NumericData
-from geoh5py.objects import ObjectType
+from geoh5py.objects import ObjectType, Points
 from geoh5py.shared import FLOAT_NDV, INTEGER_NDV
 from geoh5py.workspace import Workspace
 
@@ -82,6 +82,9 @@ def test_data_instantiation(data_class, tmp_path):
         # no more reference on data_type, so it should be gone from the workspace
         assert workspace.find_type(data_type_uid, DataType) is None
 
+        with pytest.raises(TypeError, match="Input 'data_type' must be "):
+            data.TextData(data_type="bidon")
+
 
 def _can_find(workspace, created_data):
     """Make sure we can find the created data in the workspace."""
@@ -89,3 +92,27 @@ def _can_find(workspace, created_data):
     assert len(all_data) == 1
     assert next(iter(all_data)) is created_data
     assert workspace.find_data(created_data.uid) is created_data
+
+
+def test_copy_from_extent(tmp_path):
+    # Generate a random cloud of points
+    h5file_path = tmp_path / r"testPoints.geoh5"
+    workspace = Workspace.create(h5file_path)
+    points = Points.create(
+        workspace,
+        vertices=np.vstack((np.arange(20), np.arange(20), np.zeros(20))).T,
+        allow_move=False,
+    )
+
+    data_ = points.add_data(
+        {"DataValues": {"association": "VERTEX", "values": np.random.randn(20)}}
+    )
+
+    cropped_data = data_.copy_from_extent(np.vstack([[5, 5], [10, 10]]))
+
+    # prepare validation
+    validation = data_.values
+    validation[:5] = np.nan
+    validation[11:] = np.nan
+
+    np.testing.assert_array_equal(cropped_data.values, validation)

--- a/tests/group_test.py
+++ b/tests/group_test.py
@@ -18,6 +18,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from geoh5py.groups import ContainerGroup, SimPEGGroup
 from geoh5py.shared.utils import compare_entities
 from geoh5py.ui_json import constants, templates
@@ -55,3 +57,15 @@ def test_simpeg_group(tmp_path):
     new_workspace = Workspace(tmp_path / r"testGroup2.geoh5")
     rec_obj = new_workspace.get_entity(group.uid)[0]
     compare_entities(group, rec_obj, ignore=["_parent"])
+
+
+def test_add_children_group(tmp_path):
+    h5file_path = tmp_path / r"testGroup.geoh5"
+    group_name = "MyTestContainer"
+
+    # Create a workspace
+    workspace = Workspace.create(h5file_path)
+    group = ContainerGroup.create(workspace, name=group_name)
+
+    with pytest.raises(TypeError, match="Child must be an instance"):
+        group.add_children("bidon")

--- a/tests/property_group_test.py
+++ b/tests/property_group_test.py
@@ -137,11 +137,6 @@ def test_create_property_group(tmp_path):
 
         assert isinstance(workspace.property_groups, list)
 
-        with pytest.raises(
-            TypeError, match="property_group must be a PropertyGroup instance"
-        ):
-            workspace.register_property_group("bidon")
-
         property_group_from_object = curve.get_entity("myGroup")[0]
 
         assert property_group_from_object == property_group_test

--- a/tests/remove_root_test.py
+++ b/tests/remove_root_test.py
@@ -130,7 +130,3 @@ def test_remove_root(tmp_path: Path):
         assert points2.reference_to_uid(points2.children[0].uid) == [
             points2.children[0].uid
         ]
-
-        # will be deprecated
-        with pytest.warns(DeprecationWarning, match="Entity.save()"):
-            points2.save()


### PR DESCRIPTION
**GEOPY-1319 - add_children consistency**
Split entity into 2 classes:

Entity and EntityConcatenator

The first one is used for all object
The second deal with children that are needed for group and object