### PR TITLE
GEOPY-1364: facilate metadata assignation to object

### DIFF
--- a/geoh5py/objects/surveys/direct_current.py
+++ b/geoh5py/objects/surveys/direct_current.py
@@ -235,12 +235,20 @@ class BaseElectrode(Curve, ABC):
     def metadata(self, values: dict | None):
         if isinstance(values, dict):
             default_keys = ["Current Electrodes", "Potential Electrodes"]
-            if sorted(list(values.keys())) != default_keys:
+
+            if self.metadata:
+                existing_keys = self.metadata.copy()
+                existing_keys.update(values)
+            else:
+                existing_keys = values
+
+            # check if metadata has the required keys
+            if not all(key in existing_keys for key in default_keys):
                 raise ValueError(f"Input metadata must have for keys {default_keys}")
 
             for key in default_keys:
-                if self.workspace.get_entity(values[key])[0] is None:
-                    raise IndexError(f"Input {key} uuid not present in Workspace")
+                if self.workspace.get_entity(existing_keys[key])[0] is None:
+                    raise KeyError(f"Input {key} uuid not present in Workspace")
 
         super(Curve, Curve).metadata.fset(self, values)  # type: ignore
 

--- a/geoh5py/objects/surveys/electromagnetics/base.py
+++ b/geoh5py/objects/surveys/electromagnetics/base.py
@@ -15,7 +15,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member, too-many-lines
+# pylint: disable=no-member, too-many-lines, too-many-ancestors
 # mypy: disable-error-code="attr-defined"
 
 from __future__ import annotations
@@ -337,19 +337,18 @@ class BaseEMSurvey(ObjectBase, ABC):  # pylint: disable=too-many-public-methods
 
         :param entries: Metadata key value pairs.
         """
-        metadata = self.metadata.copy()
+        em_metadata = self.metadata.copy().pop("EM Dataset", {})
+
         for key, value in entries.items():
             if key == "Property groups":
                 self._edit_validate_property_groups(value)
-
             elif value is None:
-                if key in metadata["EM Dataset"]:
-                    del metadata["EM Dataset"][key]
-
+                if key in em_metadata:
+                    del em_metadata[key]
             else:
-                metadata["EM Dataset"][key] = value
+                em_metadata[key] = value
 
-        self.metadata = metadata
+        self.metadata = {"EM Dataset": em_metadata}
 
     @property
     def input_type(self) -> str | None:

--- a/geoh5py/objects/surveys/electromagnetics/tipper.py
+++ b/geoh5py/objects/surveys/electromagnetics/tipper.py
@@ -90,7 +90,7 @@ class TipperSurvey(FEMSurvey, AirborneEMSurvey):
             )
 
         self._base_stations = base
-        self.edit_metadata({"Base stations": base.uid})
+        self.edit_em_metadata({"Base stations": base.uid})
 
     def copy_from_extent(
         self,

--- a/geoh5py/shared/entity.py
+++ b/geoh5py/shared/entity.py
@@ -232,24 +232,17 @@ class Entity(ABC):
 
     @metadata.setter
     def metadata(self, value: dict | None):
-        if value is not None:
-            if not isinstance(value, dict):
-                raise TypeError(
-                    "Input metadata must be of type dict or None"
-                    f" find '{type(value)}'."
-                )
-
-            # ensure metadata is loaded
-            if getattr(self, "_metadata", None) is None:
-                self._metadata = self.workspace.fetch_metadata(self.uid)
-
-            if isinstance(self._metadata, dict):
-                self._metadata.update(value)
+        if isinstance(value, dict):
+            if isinstance(self.metadata, dict):
+                self._metadata.update(value)  # type: ignore
             else:
                 self._metadata = value
-        else:  # remove the metadata
+        elif value is None:  # remove the metadata
             self._metadata = None
-
+        else:
+            raise TypeError(
+                "Input metadata must be of type dict or None" f" find '{type(value)}'."
+            )
         self.workspace.update_attribute(self, "metadata")
 
     @property

--- a/geoh5py/shared/entity.py
+++ b/geoh5py/shared/entity.py
@@ -161,13 +161,7 @@ class Entity(ABC):
         }
 
         # update the metadata
-        metadata = self.metadata
-        if isinstance(metadata, dict):
-            metadata["Coordinate Reference System"] = coordinate_reference_system
-        else:
-            metadata = {"Coordinate Reference System": coordinate_reference_system}
-
-        self.metadata = metadata
+        self.metadata = {"Coordinate Reference System": coordinate_reference_system}
 
     @classmethod
     def create(cls, workspace, **kwargs):
@@ -228,6 +222,8 @@ class Entity(ABC):
     def metadata(self) -> dict | None:
         """
         Metadata attached to the entity.
+        To update the metadata, use the setter method.
+        To remove the metadata, set it to None.
         """
         if getattr(self, "_metadata", None) is None:
             self._metadata = self.workspace.fetch_metadata(self.uid)
@@ -237,10 +233,23 @@ class Entity(ABC):
     @metadata.setter
     def metadata(self, value: dict | None):
         if value is not None:
-            assert isinstance(
-                value, (dict, str)
-            ), f"Input metadata must be of type {dict} or None"
-        self._metadata = value
+            if not isinstance(value, dict):
+                raise TypeError(
+                    "Input metadata must be of type dict or None"
+                    f" find '{type(value)}'."
+                )
+
+            # ensure metadata is loaded
+            if getattr(self, "_metadata", None) is None:
+                self._metadata = self.workspace.fetch_metadata(self.uid)
+
+            if isinstance(self._metadata, dict):
+                self._metadata.update(value)
+            else:
+                self._metadata = value
+        else:  # remove the metadata
+            self._metadata = None
+
         self.workspace.update_attribute(self, "metadata")
 
     @property

--- a/tests/copy_entity_test.py
+++ b/tests/copy_entity_test.py
@@ -85,7 +85,7 @@ def test_copy_entity(tmp_path: Path):
         get_entity = entity.get_entity(entity.uid)
         assert isinstance(get_entity, list)
 
-        with pytest.raises(AssertionError, match="Input metadata must be of type"):
+        with pytest.raises(TypeError, match="Input metadata must be of type"):
             entity.metadata = 0
 
     with pytest.raises(FileExistsError, match="File "):

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -1,0 +1,48 @@
+#  Copyright (c) 2024 Mira Geoscience Ltd.
+#
+#  This file is part of geoh5py.
+#
+#  geoh5py is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  geoh5py is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from geoh5py.objects import Points
+from geoh5py.workspace import Workspace
+
+
+def test_metadata(tmp_path):
+
+    h5file_path = tmp_path / r"testPoints.geoh5"
+    workspace = Workspace.create(h5file_path)
+    points = Points.create(workspace, vertices=np.random.randn(12, 3), allow_move=False)
+
+    assert points.metadata is None
+
+    points.metadata = {"test": "test"}
+
+    assert points.metadata == {"test": "test"}
+
+    points.metadata = {"test2": "test"}
+
+    assert points.metadata == {"test": "test", "test2": "test"}
+
+    points.metadata = None
+
+    assert points.metadata is None
+
+    with pytest.raises(TypeError, match="Input metadata must be of type"):
+        points.metadata = "bidon"

--- a/tests/survey_dcip_test.py
+++ b/tests/survey_dcip_test.py
@@ -92,17 +92,17 @@ def test_create_survey_dcip(tmp_path):
             "Potential Electrodes": uuid.uuid4(),
             "One too many key": uuid.uuid4(),
         }
-        with pytest.raises(ValueError):
+        with pytest.raises(KeyError, match="Input"):
             potentials.metadata = fake_meta
 
         del fake_meta["One too many key"]
 
-        with pytest.raises(IndexError):
+        with pytest.raises(KeyError, match="Input"):
             potentials.metadata = fake_meta
 
         fake_meta["Current Electrodes"] = currents.uid
 
-        with pytest.raises(IndexError):
+        with pytest.raises(KeyError, match="Input"):
             potentials.metadata = fake_meta
 
         fake_meta["Potential Electrodes"] = potentials.uid
@@ -165,3 +165,16 @@ def test_create_survey_dcip(tmp_path):
         compare_entities(
             potentials, potentials_rec, ignore=["_current_electrodes", "_parent"]
         )
+
+        currents.metadata = {
+            "Current Electrodes": currents.uid,
+            "Potential Electrodes": potentials.uid,
+        }
+
+        currents.metadata = {"Just a general comment": "This is a test"}
+
+        assert list(currents.metadata.keys()) == [
+            "Current Electrodes",
+            "Potential Electrodes",
+            "Just a general comment",
+        ]

--- a/tests/survey_fem_test.py
+++ b/tests/survey_fem_test.py
@@ -235,14 +235,14 @@ def test_survey_airborne_fem_data(tmp_path):
     # Create another property group and assign by name
     prop_group = receivers.add_data_to_group(data, "NewGroup")
 
-    receivers.edit_metadata({"Property groups": prop_group})
+    receivers.edit_em_metadata({"Property groups": prop_group})
 
     assert (
         prop_group.name in receivers.metadata["EM Dataset"]["Property groups"]
         and len(receivers.metadata["EM Dataset"]["Property groups"]) == 2
     ), "Failed to add the property group to list of metadata."
 
-    receivers.edit_metadata({"Property groups": None})
+    receivers.edit_em_metadata({"Property groups": None})
 
     assert (
         len(receivers.metadata["EM Dataset"]["Property groups"]) == 0
@@ -251,7 +251,7 @@ def test_survey_airborne_fem_data(tmp_path):
     with pytest.raises(
         TypeError, match="Input value for 'Property groups' must be a PropertyGroup"
     ):
-        receivers.edit_metadata({"Property groups": 1234})
+        receivers.edit_em_metadata({"Property groups": 1234})
 
     with pytest.raises(
         TypeError,

--- a/tests/survey_tem_test.py
+++ b/tests/survey_tem_test.py
@@ -235,14 +235,14 @@ def test_survey_airborne_tem_data(tmp_path):
     # Create another property group and assign by name
     prop_group = receivers.add_data_to_group(data, "NewGroup")
 
-    receivers.edit_metadata({"Property groups": prop_group})
+    receivers.edit_em_metadata({"Property groups": prop_group})
 
     assert (
         prop_group.name in receivers.metadata["EM Dataset"]["Property groups"]
         and len(receivers.metadata["EM Dataset"]["Property groups"]) == 2
     ), "Failed to add the property group to list of metadata."
 
-    receivers.edit_metadata({"Property groups": None})
+    receivers.edit_em_metadata({"Property groups": None})
 
     assert (
         len(receivers.metadata["EM Dataset"]["Property groups"]) == 0
@@ -251,7 +251,7 @@ def test_survey_airborne_tem_data(tmp_path):
     with pytest.raises(
         TypeError, match="Input value for 'Property groups' must be a PropertyGroup"
     ):
-        receivers.edit_metadata({"Property groups": 1234})
+        receivers.edit_em_metadata({"Property groups": 1234})
 
     with pytest.raises(
         TypeError,


### PR DESCRIPTION
**GEOPY-1364 - facilate metadata assignation to object**
update metadata to not rewrite everything and push to existing dictionary.

Change usage and inheritance of this function in geoh5py

Test everything

PS: my-py doesn't like super() functions, I ignore it.