### PR TITLE
GEOPY-1450: Geoimage in geoh5py import tiff return black image

### DIFF
--- a/geoh5py/objects/geo_image.py
+++ b/geoh5py/objects/geo_image.py
@@ -351,6 +351,7 @@ class GeoImage(ObjectBase):
 
         :return: List of new Data objects.
         """
+        convert_to_grid = False
         if isinstance(image, np.ndarray) and image.ndim in [2, 3]:
             if image.ndim == 3 and image.shape[2] != 3:
                 raise ValueError(
@@ -371,15 +372,16 @@ class GeoImage(ObjectBase):
                 raise ValueError(f"Input image file {image} does not exist.")
 
             image = Image.open(image)
-
             # if the image is a tiff save tag information
             if isinstance(image, TiffImageFile):
                 self.tag = image
+                convert_to_grid = True
 
         elif isinstance(image, bytes):
             image = Image.open(BytesIO(image))
         elif isinstance(image, TiffImageFile):
             self.tag = image
+            convert_to_grid = True
         elif not isinstance(image, Image.Image):
             raise ValueError(
                 "Input 'value' for the 'image' property must be "
@@ -402,6 +404,10 @@ class GeoImage(ObjectBase):
             image = self.add_file(str(temp_file))
             image.name = "GeoImageMesh_Image"
             image.entity_type.name = "GeoImageMesh_Image"
+
+        # quick and dirty fix: create a grid if image is tiff
+        if convert_to_grid:
+            self.to_grid2d(name=self.name + "_grid2d")
 
     @property
     def image_data(self):

--- a/geoh5py/objects/geo_image.py
+++ b/geoh5py/objects/geo_image.py
@@ -352,6 +352,7 @@ class GeoImage(ObjectBase):
         :return: List of new Data objects.
         """
         convert_to_grid = False
+        # todo: this should be changed in the future to accept tiff images
         if isinstance(image, np.ndarray) and image.ndim in [2, 3]:
             if image.ndim == 3 and image.shape[2] != 3:
                 raise ValueError(
@@ -372,22 +373,19 @@ class GeoImage(ObjectBase):
                 raise ValueError(f"Input image file {image} does not exist.")
 
             image = Image.open(image)
-            # if the image is a tiff save tag information
-            if isinstance(image, TiffImageFile):
-                self.tag = image
-                convert_to_grid = True
-
         elif isinstance(image, bytes):
             image = Image.open(BytesIO(image))
-        elif isinstance(image, TiffImageFile):
-            self.tag = image
-            convert_to_grid = True
+
         elif not isinstance(image, Image.Image):
             raise ValueError(
                 "Input 'value' for the 'image' property must be "
                 "a 2D or 3D numpy.ndarray, bytes, PIL.Image or a path to an existing image."
                 f"Get type {type(image)} instead."
             )
+        # if the image is a tiff save tag information
+        if isinstance(image, TiffImageFile):
+            self.tag = image
+            convert_to_grid = True
 
         with TemporaryDirectory() as tempdir:
             if image.mode not in PILLOW_ARGUMENTS:

--- a/geoh5py/shared/conversion/geo_image.py
+++ b/geoh5py/shared/conversion/geo_image.py
@@ -76,13 +76,13 @@ class GeoImageConversion(BaseConversion):
         :param values: Input image values as an array of int.
         :param output: the new :obj:'geoh5py.objects.grid2d.Grid2D'.
         """
-        if values.ndim > 1:
-            values = np.asarray(Image.fromarray(values).convert("L"))
+        if values.ndim != 2:
+            raise ValueError("To export to gray image, the array must be 2d. ")
 
         output.add_data(
             data={
                 "band[0]": {
-                    "values": values.astype(np.uint32)[::-1].flatten(),
+                    "values": values[::-1].flatten(),
                     "association": "CELL",
                 }
             }
@@ -91,7 +91,7 @@ class GeoImageConversion(BaseConversion):
     @staticmethod
     def add_color_data(values: np.ndarray, output: Grid2D):
         """
-        Send the image color bands to :obj:'geoh5py.data.integer_data.IntegerData'.
+        Send the image color bands to data.
 
         :param values: Input image values as an array of int.
         :param output: the new :obj:'geoh5py.objects.grid2d.Grid2D'.
@@ -103,7 +103,7 @@ class GeoImageConversion(BaseConversion):
             output.add_data(
                 {
                     f"band[{ind}]": {
-                        "values": values.astype(np.uint32)[::-1, :, ind].flatten(),
+                        "values": values[::-1, :, ind].flatten(),
                         "association": "CELL",
                     }
                 }

--- a/tests/geo_image_test.py
+++ b/tests/geo_image_test.py
@@ -586,3 +586,23 @@ def test_copy_from_extent_geoimage(tmp_path):
                 BytesIO(geoimage.image_data.values).getbuffer().nbytes
                 > BytesIO(geoimage2.image_data.values).getbuffer().nbytes
             )
+
+
+def test_complex_tiff(tmp_path):
+    image_path = tmp_path / r"testtif.tif"
+    workspace_path = tmp_path / r"geo_image_test.geoh5"
+
+    # create a tiff
+    image = Image.fromarray(1000 * np.random.randn(128, 128).astype("float32"))
+    image.save(image_path)
+
+    with Workspace.create(workspace_path) as workspace:
+        # load image
+        geoimage = GeoImage.create(workspace, name="test_area", image=str(image_path))
+
+        grid = workspace.get_entity("test_area_grid2d")[0]
+
+        assert all(
+            np.array(geoimage.image)[::-1].flatten()
+            == grid.get_data("band[0]")[0].values
+        )


### PR DESCRIPTION
**GEOPY-1450 - Geoimage in geoh5py import tiff return black image**
Change the conversion from geoimage to grid, not converting data type anymore.
If the input image is a tiff, the data is automaticly duplicated as a grid