### PR TITLE
GEOPY-1481: pylint runs on exclude folder geoh5py/interfaces and reports errors

### DIFF
--- a/geoh5py/interfaces/api.pyi
+++ b/geoh5py/interfaces/api.pyi
@@ -15,6 +15,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+# pylint: skip-file
 # pylint: disable=unused-import,no-name-in-module
 # flake8: noqa
 

--- a/geoh5py/interfaces/data.pyi
+++ b/geoh5py/interfaces/data.pyi
@@ -15,6 +15,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+# pylint: skip-file
 # pylint: disable=unused-argument,no-self-use,no-name-in-module
 # flake8: noqa
 

--- a/geoh5py/interfaces/groups.pyi
+++ b/geoh5py/interfaces/groups.pyi
@@ -15,6 +15,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+# pylint: skip-file
 # pylint: disable=unused-argument,no-self-use,no-name-in-module
 # flake8: noqa
 

--- a/geoh5py/interfaces/objects.pyi
+++ b/geoh5py/interfaces/objects.pyi
@@ -15,6 +15,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+# pylint: skip-file
 # pylint: disable=unused-argument,no-self-use,no-name-in-module,too-many-public-methods
 # flake8: noqa
 

--- a/geoh5py/interfaces/shared.pyi
+++ b/geoh5py/interfaces/shared.pyi
@@ -15,6 +15,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+# pylint: skip-file
 # pylint: disable=unused-argument,no-self-use,no-name-in-module
 # flake8: noqa
 

--- a/geoh5py/interfaces/workspace.pyi
+++ b/geoh5py/interfaces/workspace.pyi
@@ -15,6 +15,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
 
+# pylint: skip-file
 # pylint: disable=unused-argument,no-self-use,no-name-in-module
 # flake8: noqa
 


### PR DESCRIPTION
**GEOPY-1481 - pylint runs on exclude folder geoh5py/interfaces and reports errors**
