### PR TITLE
GEOPY-1539: Add a locations property to expose vertices or centroids on geoh5py.objects.ObjectBase

### DIFF
--- a/geoh5py/objects/object_base.py
+++ b/geoh5py/objects/object_base.py
@@ -36,6 +36,7 @@ from ..shared.utils import clear_array_attributes
 from .object_type import ObjectType
 
 if TYPE_CHECKING:
+
     from ..workspace import Workspace
 
 
@@ -565,6 +566,17 @@ class ObjectBase(EntityContainer):
         :obj:`numpy.array` of :obj:`float`, shape (\*, 3): Array of x, y, z coordinates
         defining the position of points in 3D space.
         """
+
+    @property
+    def locations(self):
+        """Exposes the vertices or centroids of the object."""
+        out = None
+        if hasattr(self, "vertices"):
+            out = self.vertices
+        if hasattr(self, "centroids"):
+            out = self.centroids
+
+        return out
 
     @property
     def converter(self):

--- a/tests/octree_test.py
+++ b/tests/octree_test.py
@@ -80,6 +80,7 @@ def test_octree(tmp_path: Path):
         rec_obj = new_workspace.get_entity(name)[0]
 
         compare_entities(mesh, rec_obj)
+        assert np.allclose(mesh.centroids, mesh.locations)
 
 
 def test_change_octree_cells(tmp_path: Path):

--- a/tests/point_data_test.py
+++ b/tests/point_data_test.py
@@ -75,6 +75,8 @@ def test_create_point_data(tmp_path):
             etype_handle.get("StatsCache") is None
         ), "StatsCache was not properly deleted on update of values"
 
+    assert np.allclose(points.vertices, points.locations)
+
 
 def test_remove_point_data(tmp_path):
     # Generate a random cloud of points


### PR DESCRIPTION
**GEOPY-1539 - Add a locations property to expose vertices or centroids on geoh5py.objects.ObjectBase**
