### PR TITLE
GEOPY-1541: Protect against object associated data with array values

### DIFF
--- a/geoh5py/data/numeric_data.py
+++ b/geoh5py/data/numeric_data.py
@@ -87,7 +87,7 @@ class NumericData(Data, ABC):
             return full_vector
 
         if (
-            len(values) != self.n_values
+            len(values) > self.n_values
             and self.association is not DataAssociationEnum.OBJECT
         ):
             raise ValueError(

--- a/geoh5py/data/numeric_data.py
+++ b/geoh5py/data/numeric_data.py
@@ -23,6 +23,7 @@ from warnings import warn
 import numpy as np
 
 from .data import Data, PrimitiveTypeEnum
+from .data_association_enum import DataAssociationEnum
 
 
 class NumericData(Data, ABC):
@@ -85,7 +86,10 @@ class NumericData(Data, ABC):
             full_vector[: len(np.ravel(values))] = np.ravel(values)
             return full_vector
 
-        if len(values) > self.n_values:
+        if (
+            len(values) != self.n_values
+            and self.association is not DataAssociationEnum.OBJECT
+        ):
             raise ValueError(
                 f"Input 'values' of shape({self.n_values},) expected. "
                 f"Array of shape{values.shape} provided.)"

--- a/tests/clip_vertex_data_test.py
+++ b/tests/clip_vertex_data_test.py
@@ -88,6 +88,10 @@ def test_clip_curve_data(tmp_path):
                     "association": "CELL",
                     "values": np.random.randn(curve.n_cells),
                 },
+                "ObjectValues": {
+                    "association": "OBJECT",
+                    "values": np.random.randn(1000),
+                },
             }
         )
         with Workspace.create(tmp_path / r"testClipCurve_copy.geoh5") as new_workspace:
@@ -111,6 +115,10 @@ def test_clip_curve_data(tmp_path):
             assert np.all(
                 clipping_inverse.get_data("CellValues")[0].values
                 == np.r_[data[1].values[0:9], data[1].values[-1]]
+            )
+
+            np.testing.assert_allclose(
+                data[2].values, clipping_inverse.get_data("ObjectValues")[0].values
             )
 
     # Repeat with 2D bounds - single point left


### PR DESCRIPTION
**GEOPY-1541 - Protect against object associated data with array values**
(cherry picked from commit bc42b1bab28729ec06fc10454673f2c3bbcd0ae6)