### PR TITLE
GEOPY-1770: add a method to update metadata without rewriting everything

### DIFF
--- a/geoh5py/shared/entity.py
+++ b/geoh5py/shared/entity.py
@@ -310,6 +310,16 @@ class Entity(ABC):  # pylint: disable=too-many-instance-attributes
         if self.on_file:
             self.workspace.update_attribute(self, "metadata")
 
+    def update_metadata(self, value: dict | None):
+        """
+        Update the metadata of the entity.
+
+        :param value: Metadata to update.
+        """
+        if isinstance(self.metadata, dict) and isinstance(value, dict):
+            value = {**self.metadata, **value}
+        self.metadata = value
+
     @staticmethod
     def validate_metadata(value) -> dict | None:
         if isinstance(value, np.ndarray):

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -39,6 +39,10 @@ def test_metadata(tmp_path):
 
     assert points.metadata == {"test2": "test"}
 
+    points.update_metadata({"test3": "test3"})
+
+    assert points.metadata == {"test2": "test", "test3": "test3"}
+
     points.metadata = None
 
     assert points.metadata is None


### PR DESCRIPTION
**GEOPY-1770 - add a method to update metadata without rewriting everything**
add a new function "update_metadata" to entity