### PR TITLE
GEOPY-1755: create an object to access all the data of a property group in a recarray

### DIFF
--- a/geoh5py/data/blob_data.py
+++ b/geoh5py/data/blob_data.py
@@ -17,17 +17,12 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
 from typing import Any
 
 from .data import Data, PrimitiveTypeEnum
 
 
 class BlobData(Data):
-    @property
-    def formatted_values(self):
-        return deepcopy(self.values)
-
     @classmethod
     def primitive_type(cls) -> PrimitiveTypeEnum:
         return PrimitiveTypeEnum.BLOB

--- a/geoh5py/data/data.py
+++ b/geoh5py/data/data.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import uuid
 from abc import abstractmethod
-from copy import deepcopy
 from typing import Any
 
 import numpy as np
@@ -154,7 +153,7 @@ class Data(Entity):
         """
         The data with the right format for Geoscience ANALYST.
         """
-        return deepcopy(self.values)
+        return self.values
 
     @property
     def n_values(self) -> int | None:

--- a/geoh5py/data/data.py
+++ b/geoh5py/data/data.py
@@ -244,15 +244,15 @@ class Data(Entity):
             return mask_by_extent(self.parent.vertices, extent, inverse=inverse)
 
         if self.association is DataAssociationEnum.CELL:
-            if hasattr(self.parent, "centroids"):
-                return mask_by_extent(self.parent.centroids, extent, inverse=inverse)
-
-            if hasattr(self.parent, "vertices") and hasattr(self.parent, "cells"):
+            if hasattr(self.parent, "vertices") and hasattr(self.parent, "_cells"):
                 indices = mask_by_extent(self.parent.vertices, extent, inverse=inverse)
                 if indices is not None:
                     indices = np.all(indices[self.parent.cells], axis=1)
 
                 return indices
+
+            if hasattr(self.parent, "centroids"):
+                return mask_by_extent(self.parent.centroids, extent, inverse=inverse)
 
         return None
 

--- a/geoh5py/data/primitive_type_enum.py
+++ b/geoh5py/data/primitive_type_enum.py
@@ -59,7 +59,7 @@ class DataTypeEnum(Enum):
     BOOLEAN = bool
 
     @classmethod
-    def from_primitive_type(cls, primitive_type: PrimitiveTypeEnum) -> DataTypeEnum:
+    def from_primitive_type(cls, primitive_type: PrimitiveTypeEnum):
         """
         Get the data type from the primitive type.
 

--- a/geoh5py/data/primitive_type_enum.py
+++ b/geoh5py/data/primitive_type_enum.py
@@ -59,7 +59,7 @@ class DataTypeEnum(Enum):
     BOOLEAN = bool
 
     @classmethod
-    def from_primitive_type(cls, primitive_type: PrimitiveTypeEnum):
+    def from_primitive_type(cls, primitive_type: PrimitiveTypeEnum) -> type:
         """
         Get the data type from the primitive type.
 

--- a/geoh5py/data/text_data.py
+++ b/geoh5py/data/text_data.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import json
-from copy import deepcopy
 
 import numpy as np
 from numpy import ndarray
@@ -36,8 +35,6 @@ def text_formating(values: None | np.ndarray | str) -> ndarray | None:
 
     :return: The formatted values.
     """
-    values = deepcopy(values)
-
     # todo: values[0] seems dangerous here
     if values is None or isinstance(values[0], bytes):
         return values
@@ -100,8 +97,7 @@ class CommentsData(Data):
 
     @property
     def formatted_values(self):
-        values = deepcopy(self.values)
-        return json.dumps(dict_mapper(values, [as_str_if_uuid]))
+        return json.dumps(dict_mapper(self.values, [as_str_if_uuid]))
 
     @classmethod
     def primitive_type(cls) -> PrimitiveTypeEnum:

--- a/geoh5py/groups/property_group.py
+++ b/geoh5py/groups/property_group.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Literal
 
 from ..data import Data, DataAssociationEnum
 from ..shared.utils import map_attributes
+from .property_group_table import PropertyGroupTable
 
 
 if TYPE_CHECKING:
@@ -56,8 +57,6 @@ class PropertyGroup:
         "Properties": "properties",
         "Property Group Type": "property_group_type",
     }
-    _name: str
-    _uid: uuid.UUID
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -74,6 +73,7 @@ class PropertyGroup:
         self._allow_delete = True
         self.on_file = on_file
         self.association = association
+        self._property_table = PropertyGroupTable(self)
 
         if not hasattr(parent, "_property_groups"):
             raise AttributeError(
@@ -270,6 +270,13 @@ class PropertyGroup:
             return
 
         self.parent.workspace.add_or_update_property_group(self)
+
+    @property
+    def property_table(self) -> PropertyGroupTable:
+        """
+        Create an object to access the data of the property group.
+        """
+        return self._property_table
 
     @property
     def uid(self) -> uuid.UUID:

--- a/geoh5py/groups/property_group.py
+++ b/geoh5py/groups/property_group.py
@@ -112,6 +112,7 @@ class PropertyGroup:
         if properties:
             self._properties = properties
             self.parent.workspace.add_or_update_property_group(self)
+            self.property_table.update()
 
     @property
     def allow_delete(self) -> bool:
@@ -270,6 +271,7 @@ class PropertyGroup:
             return
 
         self.parent.workspace.add_or_update_property_group(self)
+        self.property_table.update()
 
     @property
     def property_table(self) -> PropertyGroupTable:

--- a/geoh5py/groups/property_group.py
+++ b/geoh5py/groups/property_group.py
@@ -214,11 +214,6 @@ class PropertyGroup:
         if data_list is None:
             return None
 
-        if not isinstance(data_list, Iterable):
-            raise TypeError(
-                f"Properties must be an iterable of Data. Provided {data_list}"
-            )
-
         return remove_duplicates_in_list(
             [self._validate_data(uid) for uid in data_list]
         )

--- a/geoh5py/groups/property_group_table.py
+++ b/geoh5py/groups/property_group_table.py
@@ -23,6 +23,7 @@ from uuid import UUID
 
 import numpy as np
 
+from ..data import DataAssociationEnum
 from ..data.primitive_type_enum import DataTypeEnum
 from ..shared.utils import str2uuid, to_tuple
 
@@ -106,7 +107,7 @@ class PropertyGroupTable(ABC):
 
         for key, name in zip(keys, names, strict=False):
             dtype, nan_value = self.properties_type[key]
-            dtypes.append((name, dtype))
+            dtypes.append((str(name), dtype))
             no_data_values.append(nan_value)
 
         empty_array = np.recarray((self.size,), dtype=dtypes)
@@ -124,9 +125,9 @@ class PropertyGroupTable(ABC):
         This function is needed as a data can be both associated to cell or
         vertex in CellObjects.
         """
-        if self.property_group.association == "VERTEX":
+        if self.property_group.association == DataAssociationEnum.VERTEX:
             return "vertices"
-        if self.property_group.association == "CELL":
+        if self.property_group.association == DataAssociationEnum.CELL:
             return "centroids"
         return "locations"
 
@@ -136,15 +137,6 @@ class PropertyGroupTable(ABC):
         The property group to extract the data from.
         """
         return self._property_group
-
-    @property_group.setter
-    def property_group(self, value: PropertyGroup):
-        if not isinstance(value, PropertyGroup):
-            raise TypeError(
-                f"property_group must be a PropertyGroup, not {type(value)}"
-            )
-        self._property_group = value
-        self._properties_type = None
 
     @property
     def property_table(self) -> np.ndarray | None:
@@ -188,7 +180,7 @@ class PropertyGroupTable(ABC):
 
         for key, name in zip(keys, names_, strict=False):
             data = self.property_group.parent.get_data(key)[0]
-            output_array[name] = data.values
+            output_array[str(name)] = data.values
 
         return output_array
 

--- a/geoh5py/groups/property_group_table.py
+++ b/geoh5py/groups/property_group_table.py
@@ -28,7 +28,7 @@ from ..data.primitive_type_enum import DataTypeEnum
 from ..shared.utils import str2uuid, to_tuple
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .property_group import PropertyGroup
 
 

--- a/geoh5py/groups/property_group_table.py
+++ b/geoh5py/groups/property_group_table.py
@@ -1,0 +1,240 @@
+#  Copyright (c) 2024 Mira Geoscience Ltd.
+#
+#  This file is part of geoh5py.
+#
+#  geoh5py is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  geoh5py is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from abc import ABC
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+import numpy as np
+
+from ..data.primitive_type_enum import DataTypeEnum
+from ..shared.utils import str2uuid, to_tuple
+
+
+if TYPE_CHECKING:
+    from .property_group import PropertyGroup
+
+
+class PropertyGroupTable(ABC):
+    """
+    A class to store the information of a property group.
+
+    :param property_group: The property group to extract the data from.
+    """
+
+    locations_keys = ("X", "Y", "Z")
+
+    def __init__(self, property_group: PropertyGroup):
+        self._properties_type: dict | None = None
+        self._size: int | None = None
+
+        self._property_group: PropertyGroup = property_group
+
+    def _convert_names_to_uid(self, names: tuple[str | UUID]) -> tuple:
+        """
+        Convert the names of the properties to their UUID.
+
+        :param names: The names of the properties to find back.
+
+        :return: A list of UUID.
+        """
+
+        uuids: tuple = ()
+
+        for name in names:
+            uid = str2uuid(name)
+
+            if isinstance(uid, str):
+                data = self.property_group.parent.get_data(uid)
+                if len(data) == 0:
+                    raise ValueError(f"Data with name {name} not found.")
+                if len(data) > 1:
+                    raise ValueError(f"Multiple data with name {name} found.")
+                uid = data[0].uid
+
+            if (
+                self.property_group.properties is None
+                or not isinstance(uid, UUID)
+                or uid not in self.property_group.properties
+            ):
+                raise ValueError(f"Data '{name}' not found in the property group.")
+
+            uuids += (uid,)
+
+        if len(uuids) == 0:
+            raise ValueError(f"No data found for '{names}' in the property group.")
+
+        return uuids
+
+    def _create_empty_structured_array(
+        self,
+        keys: tuple[UUID],
+        names: tuple[Any],
+        spatial_index: bool = False,
+    ) -> np.ndarray:
+        """
+        Create an empty structured array that can contains the data.
+
+        :param keys: The list containing the data.
+        :param spatial_index: If True, the association is added to the table.
+
+        :return: an empty structured array.
+        """
+        if self.size is None or self.properties_type is None:
+            raise ValueError("The PropertyGroup has no property.")
+
+        dtypes = (
+            [(loc, np.float32) for loc in self.locations_keys] if spatial_index else []
+        )
+        no_data_values = [np.nan] * 3 if spatial_index else []
+
+        for key, name in zip(keys, names, strict=False):
+            dtype, nan_value = self.properties_type[key]
+            dtypes.append((name, dtype))
+            no_data_values.append(nan_value)
+
+        empty_array = np.recarray((self.size,), dtype=dtypes)
+
+        for name, ndv in zip(empty_array.dtype.names, no_data_values, strict=False):
+            empty_array[name].fill(ndv)
+
+        return empty_array
+
+    @property
+    def association_columns(self) -> str:
+        """
+        The columns of the association table.
+
+        This function is needed as a data can be both associated to cell or
+        vertex in CellObjects.
+        """
+        if self.property_group.association == "VERTEX":
+            return "vertices"
+        if self.property_group.association == "CELL":
+            return "centroids"
+        return "locations"
+
+    @property
+    def property_group(self) -> PropertyGroup:
+        """
+        The property group to extract the data from.
+        """
+        return self._property_group
+
+    @property_group.setter
+    def property_group(self, value: PropertyGroup):
+        if not isinstance(value, PropertyGroup):
+            raise TypeError(
+                f"property_group must be a PropertyGroup, not {type(value)}"
+            )
+        self._property_group = value
+        self._properties_type = None
+
+    @property
+    def property_table(self) -> np.ndarray | None:
+        """
+        Create a structured array with the data of the properties.
+
+        This structured array also contains the spatial index.
+
+        :return: The table with the data of the properties.
+        """
+        if self.property_group.properties is None:
+            return None
+
+        return self.property_table_by_name(
+            self.property_group.properties,  # type: ignore
+            spatial_index=True,
+        )
+
+    def property_table_by_name(
+        self, names: list[str | UUID] | str | UUID, spatial_index: bool = False
+    ) -> np.ndarray:
+        """
+        Create a structured array with the data of the properties.
+
+        :param names: The names of the properties to extract.
+        :param spatial_index: If True, the spatial index is added to the table.
+
+        :return: A table with the data of the properties.
+        """
+        names_ = to_tuple(names)
+
+        keys = self._convert_names_to_uid(names_)
+
+        output_array = self._create_empty_structured_array(keys, names_, spatial_index)
+
+        if spatial_index:
+            for idx, key in enumerate(self.locations_keys):
+                output_array[key] = getattr(
+                    self.property_group.parent, self.association_columns
+                )[:, idx]
+
+        for key, name in zip(keys, names_, strict=False):
+            data = self.property_group.parent.get_data(key)[0]
+            output_array[name] = data.values
+
+        return output_array
+
+    @property
+    def properties_type(self) -> dict | None:
+        """
+        The types of the properties in the group.
+        """
+        if self._properties_type is None:
+            self.update()
+
+        return self._properties_type
+
+    @property
+    def size(self) -> int | None:
+        """
+        The size of the properties in the group.
+        """
+        if self._size is None:
+            self.update()
+
+        return self._size
+
+    def update(self):
+        """
+        Find the dtypes for all properties in the group.
+        Also check the length of all data.
+        """
+        properties_type: dict = {}
+        sizes: list = []
+
+        if self._property_group.properties is None:
+            return
+
+        for property_ in self._property_group.properties:
+            data = self.property_group.parent.get_data(property_)[0]
+
+            dtype = DataTypeEnum.from_primitive_type(data.entity_type.primitive_type)
+            if dtype not in [np.float32, np.int32, np.uint32, bool]:
+                dtype = "O"
+
+            properties_type[property_] = (dtype, data.nan_value)
+            sizes.append(data.values.size)
+
+        if not all(size == sizes[0] for size in sizes):
+            raise ValueError("All properties must have the same length.")
+
+        self._size = sizes[0]
+        self._properties_type = properties_type

--- a/geoh5py/groups/property_group_table.py
+++ b/geoh5py/groups/property_group_table.py
@@ -68,8 +68,8 @@ class PropertyGroupTable(ABC):
         ):
             return None
 
-        keys = self.property_group.properties
-        names = (
+        keys: list[UUID] = self.property_group.properties
+        names: list[str] | list[UUID] = (
             self.property_group.properties
             if use_uids
             else self.property_group.properties_name
@@ -81,7 +81,7 @@ class PropertyGroupTable(ABC):
             for idx, key in enumerate(self.locations_keys):
                 output_array[key] = self.locations[:, idx]
 
-        for key, name in zip(keys, names, strict=False):
+        for key, name in zip(keys, names, strict=False):  # type: ignore
             data = self.property_group.parent.get_data(key)[0]
             output_array[str(name)] = data.values
 
@@ -150,13 +150,4 @@ class PropertyGroupTable(ABC):
         """
         The size of the properties in the group.
         """
-        if self.property_group.association == DataAssociationEnum.VERTEX:
-            return self.property_group.parent.n_vertices
-
-        if self.property_group.association == DataAssociationEnum.CELL:
-            return self.property_group.parent.n_cells
-
-        raise ValueError(
-            f"The association {self.property_group.association} is not supported. "
-            f"Only VERTEX and CELL associations are supported."
-        )
+        return self.locations.shape[0]

--- a/geoh5py/io/h5_writer.py
+++ b/geoh5py/io/h5_writer.py
@@ -719,7 +719,7 @@ class H5Writer:
             )
 
         with fetch_h5_handle(file, mode="r+") as h5file:
-            entity_handle, name_map = H5Writer.def_prepare_data_to_write(
+            entity_handle, name_map = H5Writer.prepare_data_to_write(
                 h5file, entity, attribute
             )
             if entity.formatted_values is None or entity_handle is None:

--- a/geoh5py/io/h5_writer.py
+++ b/geoh5py/io/h5_writer.py
@@ -768,7 +768,7 @@ class H5Writer:
         :param values: Data values.
         """
         with fetch_h5_handle(file, mode="r+") as h5file:
-            entity_handle, name_map = H5Writer.def_prepare_data_to_write(
+            entity_handle, name_map = H5Writer.prepare_data_to_write(
                 h5file, entity, attribute
             )
 

--- a/geoh5py/io/h5_writer.py
+++ b/geoh5py/io/h5_writer.py
@@ -599,7 +599,7 @@ class H5Writer:
                 )
 
     @staticmethod
-    def def_prepare_data_to_write(
+    def prepare_data_to_write(
         h5file: h5py.File, entity: Data | Group | ObjectBase, attribute: str
     ) -> tuple[h5py.Group, str] | tuple[None, None]:
         """

--- a/geoh5py/io/h5_writer.py
+++ b/geoh5py/io/h5_writer.py
@@ -24,6 +24,7 @@ import re
 import uuid
 from copy import deepcopy
 from typing import TYPE_CHECKING
+from warnings import warn
 
 import h5py
 import numpy as np
@@ -318,7 +319,7 @@ class H5Writer:
 
             if entity_handle is None:
                 return
-            if attribute in ["concatenated_attributes", "options"]:
+            if attribute == "concatenated_attributes":
                 H5Writer.write_group_values(
                     h5file, entity, attribute, compression, **kwargs
                 )
@@ -329,7 +330,7 @@ class H5Writer:
                 H5Writer.write_data_values(
                     h5file, entity, attribute, compression, **kwargs
                 )
-            elif attribute == "metadata":
+            elif attribute in ["metadata", "options"]:
                 H5Writer.write_metadata(h5file, entity, attribute, **kwargs)
             elif attribute in [
                 "cells",
@@ -693,6 +694,8 @@ class H5Writer:
                     shape=(1,),
                     **kwargs,
                 )
+            else:
+                warn(f"Writing '{values}' on '{entity.name}' failed.")
 
     @staticmethod
     def write_data_values(  # pylint: disable=too-many-branches

--- a/geoh5py/io/h5_writer.py
+++ b/geoh5py/io/h5_writer.py
@@ -657,7 +657,7 @@ class H5Writer:
             )
         # check type here
         with fetch_h5_handle(file, mode="r+") as h5file:
-            entity_handle, name_map = H5Writer.def_prepare_data_to_write(
+            entity_handle, name_map = H5Writer.prepare_data_to_write(
                 h5file, entity, attribute
             )
 

--- a/geoh5py/objects/cell_object.py
+++ b/geoh5py/objects/cell_object.py
@@ -74,10 +74,7 @@ class CellObject(Points, ABC):
         """
         Compute the centroids of the cells.
         """
-        if self.cells is None:
-            return None
-
-        return np.array([self.vertices[conn].mean(axis=0) for conn in self.cells])
+        return np.mean(self.vertices[self.cells], axis=1)
 
     @property
     def locations(self):

--- a/geoh5py/objects/cell_object.py
+++ b/geoh5py/objects/cell_object.py
@@ -69,6 +69,20 @@ class CellObject(Points, ABC):
 
         self.workspace.update_attribute(self, "cells")
 
+    @property
+    def centroids(self) -> np.ndarray | None:
+        """
+        Compute the centroids of the cells.
+        """
+        if self.cells is None:
+            return None
+
+        return np.array([self.vertices[conn].mean(axis=0) for conn in self.cells])
+
+    @property
+    def locations(self):
+        return self.vertices
+
     def mask_by_extent(
         self,
         extent: np.ndarray,

--- a/geoh5py/objects/object_base.py
+++ b/geoh5py/objects/object_base.py
@@ -19,9 +19,9 @@
 
 from __future__ import annotations
 
-import uuid
 import warnings
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 import numpy as np
 
@@ -36,11 +36,16 @@ from ..groups.property_group import GroupTypeEnum, PropertyGroup
 from ..shared import Entity
 from ..shared.conversion import BaseConversion
 from ..shared.entity_container import EntityContainer
-from ..shared.utils import box_intersect, clear_array_attributes, mask_by_extent
+from ..shared.utils import (
+    box_intersect,
+    clear_array_attributes,
+    mask_by_extent,
+    str2uuid,
+)
 from .object_type import ObjectType
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ..workspace import Workspace
 
 
@@ -166,7 +171,7 @@ class ObjectBase(EntityContainer):
 
     def add_data_to_group(
         self,
-        data: list[Data | uuid.UUID | str] | Data | uuid.UUID | str,
+        data: list[Data | UUID | str] | Data | UUID | str,
         property_group: str | PropertyGroup,
     ) -> PropertyGroup:
         """
@@ -181,37 +186,19 @@ class ObjectBase(EntityContainer):
 
         :return: The target property group.
         """
-        if isinstance(data, Data | uuid.UUID | str):
-            data = [data]
-
         if isinstance(property_group, str):
-            associations = []
-            for elem in data:
-                if isinstance(elem, uuid.UUID | str):
-                    entity = self.get_entity(elem)[0]
-                else:
-                    entity = elem
-
-                if isinstance(entity, Data) and elem in self.children:
-                    associations.append(entity.association)
-
-            associations = list(set(associations))
-            if not associations:
-                raise ValueError(
-                    "No children data found on the parent object. "
-                    "Verify that the list of data or uuid provided are children entities."
-                )
-
-            if len(associations) != 1:
-                raise ValueError("All input 'data' must have the same association.")
-
             property_group = self.fetch_property_group(
-                name=property_group, association=associations[0]
+                name=property_group, properties=data
             )
 
-        property_group.add_properties(data)
+        if isinstance(property_group, PropertyGroup):
+            property_group.add_properties(data)
+            return property_group
 
-        return property_group
+        raise TypeError(
+            "Property group must be of type PropertyGroup or str; "
+            f"got {type(property_group)} instead."
+        )
 
     @property
     def cells(self) -> np.ndarray:
@@ -220,6 +207,9 @@ class ObjectBase(EntityContainer):
         defining the connection between
         :obj:`~geoh5py.objects.object_base.ObjectBase.vertices`.
         """
+        raise AttributeError(
+            f"Object {self.__class__.__name__} does not have the attribute 'cells'."
+        )
 
     def copy(
         self,
@@ -302,6 +292,9 @@ class ObjectBase(EntityContainer):
     @property
     def faces(self) -> np.ndarray:
         """Object faces."""
+        raise AttributeError(
+            f"Object {self.__class__.__name__} does not have the attribute 'faces'."
+        )
 
     @classmethod
     def find_or_create_type(cls, workspace: Workspace, **kwargs) -> ObjectType:
@@ -315,7 +308,7 @@ class ObjectBase(EntityContainer):
         kwargs["entity_class"] = cls
         return ObjectType.find_or_create(workspace, **kwargs)
 
-    def get_property_group(self, name: uuid.UUID | str) -> list:
+    def get_property_group(self, name: UUID | str) -> list:
         """
         Get a child :obj:`~geoh5py.groups.property_group.PropertyGroup` by name.
         :param name: the reference of the property group to get.
@@ -325,11 +318,8 @@ class ObjectBase(EntityContainer):
             return [None]
 
         entities = []
-
         for child in self._property_groups:
-            if (
-                isinstance(name, uuid.UUID) and child.uid == name
-            ) or child.name == name:
+            if (isinstance(name, UUID) and child.uid == name) or child.name == name:
                 entities.append(child)
 
         if len(entities) == 0:
@@ -398,7 +388,7 @@ class ObjectBase(EntityContainer):
         )
         return self.fetch_property_group(name=name, uid=uid, **kwargs)
 
-    def get_data(self, name: str | uuid.UUID) -> list[Data]:
+    def get_data(self, name: str | UUID) -> list[Data]:
         """
         Get a child :obj:`~geoh5py.data.data.Data` by name.
 
@@ -479,6 +469,43 @@ class ObjectBase(EntityContainer):
         Post-processing function to be called after adding data.
         """
 
+    def reference_to_data(self, data: str | Data | UUID) -> Data:
+        """
+        Convert a reference to a Data object.
+
+        :param data: The data to convert.
+            It can be the name, the uuid or the data itself.
+
+        :return: The data object.
+        """
+        data = str2uuid(data)
+
+        if isinstance(data, Data):
+            if self != data.parent:
+                raise ValueError(
+                    f"Data '{data.name}' parent ({data.parent}) "
+                    f"does not match group parent ({self})."
+                )
+
+        if isinstance(data, (str, UUID)):
+            data_: list = self.get_data(data)
+            # if the data is an unloaded uid
+            if len(data_) == 0 and isinstance(data, UUID):
+                data_temp = self.workspace.load_entity(data, "data", self)
+                data_ = [] if data_temp is None else [data_temp]
+            if len(data_) == 0:
+                raise ValueError(f"Data '{data}' not found in parent {self}")
+            if len(data_) > 1:
+                raise ValueError(f"Multiple data '{data}' found in parent {self}")
+            data = data_[0]
+
+        if not isinstance(data, Data):
+            raise TypeError(
+                f"Data must be of type Data, UUID or str. Provided {type(data)}"
+            )
+
+        return data
+
     def remove_children(self, children: list[Entity | PropertyGroup]):
         """
         Remove children from the list of children entities.
@@ -496,7 +523,7 @@ class ObjectBase(EntityContainer):
 
         for child in children:
             if child not in self._children:
-                continue
+                continue  # this is dangerous, should raise an error
 
             if isinstance(child, PropertyGroup) and self._property_groups:
                 self.remove_property_group(child)
@@ -542,6 +569,9 @@ class ObjectBase(EntityContainer):
         :obj:`numpy.array` of :obj:`float`, shape (\*, 3): Array of x, y, z coordinates
         defining the position of points in 3D space.
         """
+        raise AttributeError(
+            f"Object {type(self)} does not have the attribute 'vertices'."
+        )
 
     @property
     def locations(self):
@@ -607,7 +637,7 @@ class ObjectBase(EntityContainer):
         return self._visual_parameters
 
     def remove_data_from_groups(
-        self, data: list[Data | uuid.UUID | str] | Data | uuid.UUID | str
+        self, data: list[Data | UUID | str] | Data | UUID | str
     ) -> None:
         """
         Remove data children to all

--- a/geoh5py/shared/utils.py
+++ b/geoh5py/shared/utils.py
@@ -863,5 +863,4 @@ def remove_duplicates_in_list(input_list: list) -> list:
 
     :return: The sorted list
     """
-    seen = set()
-    return [x for x in input_list if not (x in seen or seen.add(x))]
+    return sorted(set(input_list), key=input_list.index)

--- a/geoh5py/shared/utils.py
+++ b/geoh5py/shared/utils.py
@@ -833,3 +833,35 @@ def str2none(value):
     if value == "":
         return None
     return value
+
+
+def find_unique_name(name: str, names: list[str]) -> str:
+    """
+    Get a unique name not in a list of names.
+
+    :param name: The name to check.
+    :param names: The list of names to avoid.
+
+    :return: a unique name.
+    """
+
+    if name not in names:
+        return name
+
+    count = 1
+    while f"{name}({count})" in names:
+        count += 1
+
+    return f"{name}({count})"
+
+
+def remove_duplicates_in_list(input_list: list) -> list:
+    """
+    Remove duplicates from a list without changing the sorting.
+
+    :param input_list: the list to remove duplicates from.
+
+    :return: The sorted list
+    """
+    seen = set()
+    return [x for x in input_list if not (x in seen or seen.add(x))]

--- a/tests/curve_data_test.py
+++ b/tests/curve_data_test.py
@@ -90,7 +90,9 @@ def test_create_curve_data(tmp_path: Path):
             3,
         ), "Error creating curve with single vertex."
         assert len(curve.cells) == 1
-        curve = Curve.create(workspace, vertices=np.random.randn(n_data, 3))
+        curve = Curve.create(
+            workspace, vertices=np.arange(n_data * 3).reshape(n_data, 3)
+        )
         # Get and change the parts
         parts = curve.parts
         parts[-3:] = 1
@@ -105,6 +107,10 @@ def test_create_curve_data(tmp_path: Path):
             ValueError, match="New cells array must have the same shape"
         ):
             curve.cells = np.c_[1, 2]
+
+        np.array_equal(
+            np.arange(1, n_data * 3 - 2).reshape(n_data - 1, 3) + 0.5, curve.centroids
+        )
 
         curve = Curve.create(
             workspace, vertices=np.random.randn(n_data, 3), name=curve_name, cells=cells

--- a/tests/delete_entity_test.py
+++ b/tests/delete_entity_test.py
@@ -56,10 +56,12 @@ def test_delete_entities(tmp_path: Path):
                     },
                     property_group="myGroup",
                 )
+
             else:
                 curve_2.add_data(
                     {f"Period{i + 1}": {"values": values}}, property_group="myGroup"
                 )
+
         uid_out = curve_2.children[1].uid
 
         curve_2.remove_children(curve_2.children[0])
@@ -95,6 +97,7 @@ def test_delete_entities(tmp_path: Path):
         assert (
             len(workspace.groups) == 2
         ), "Group was not fully removed from the workspace."
+
         assert (
             len(workspace.objects) == 1
         ), "Object was not fully removed from the workspace."

--- a/tests/grid_2d_test.py
+++ b/tests/grid_2d_test.py
@@ -55,6 +55,14 @@ def test_attribute_setters():
                 dip="90",
             )
 
+        grid = Grid2D.create(workspace_context)
+
+        with pytest.raises(AttributeError, match="Object Grid2D does not."):
+            _ = grid.faces
+
+        with pytest.raises(TypeError, match="Attribute 'last_focus'"):
+            grid.last_focus = 666
+
 
 def test_create_grid_2d_data(tmp_path):
     name = "MyTestGrid2D"

--- a/tests/modify_property_group_test.py
+++ b/tests/modify_property_group_test.py
@@ -29,7 +29,8 @@ from geoh5py.workspace import Workspace
 def test_modify_property_group(tmp_path):
     def compare_objects(object_a, object_b, ignore=None):
         if ignore is None:
-            ignore = ["_workspace", "_children", "_parent"]
+            ignore = ["_workspace", "_children", "_parent", "_property_table"]
+
         for attr in object_a.__dict__.keys():
             if attr in ignore:
                 continue
@@ -89,6 +90,8 @@ def test_modify_property_group(tmp_path):
         # Read the property_group back in
         rec_curve = workspace.get_entity(obj_name)[0]
         rec_prop_group = rec_curve.fetch_property_group(name="myGroup")
+        print(rec_prop_group, rec_prop_group.uid)
+        print(prop_group, prop_group.uid)
         compare_objects(rec_prop_group, prop_group)
 
         with pytest.raises(DeprecationWarning):

--- a/tests/modify_property_group_test.py
+++ b/tests/modify_property_group_test.py
@@ -90,8 +90,7 @@ def test_modify_property_group(tmp_path):
         # Read the property_group back in
         rec_curve = workspace.get_entity(obj_name)[0]
         rec_prop_group = rec_curve.fetch_property_group(name="myGroup")
-        print(rec_prop_group, rec_prop_group.uid)
-        print(prop_group, prop_group.uid)
+
         compare_objects(rec_prop_group, prop_group)
 
         with pytest.raises(DeprecationWarning):

--- a/tests/monitored_update_test.py
+++ b/tests/monitored_update_test.py
@@ -61,8 +61,10 @@ def test_monitored_directory_copy(tmp_path: Path):
             rec_entity = new_workspace.get_entity(entity.uid)[0]
             rec_data = new_workspace.get_entity(entity.children[0].uid)[0]
 
-            compare_entities(entity, rec_entity, ignore=["_parent"])
-            compare_entities(entity.children[0], rec_data, ignore=["_parent"])
+            compare_entities(entity, rec_entity, ignore=["_parent", "_property_table"])
+            compare_entities(
+                entity.children[0], rec_data, ignore=["_parent", "_property_table"]
+            )
 
         new_file = monitored_directory_copy(tmp_path, points, copy_children=False)
         new_workspace = Workspace(new_file)

--- a/tests/point_data_test.py
+++ b/tests/point_data_test.py
@@ -49,6 +49,10 @@ def test_create_point_data(tmp_path):
     tag = points.add_data(
         {"my_comment": {"association": "OBJECT", "values": "hello_world"}}
     )
+
+    with pytest.raises(TypeError, match="Given value to data"):
+        points.add_data({"my_comment": "bidon"})
+
     # Change some data attributes for testing
     data.allow_delete = False
     data.allow_move = True

--- a/tests/property_group_test.py
+++ b/tests/property_group_test.py
@@ -188,9 +188,6 @@ def test_property_group_errors(tmp_path):
 
         prop_group = curve.fetch_property_group(name="myGroup")
 
-        with pytest.raises(AttributeError, match="can't set attribute 'properties'"):
-            prop_group.properties = "bidon"
-
         with pytest.raises(TypeError, match="Name must be"):
             PropertyGroup(parent=curve, name=42)  # type: ignore
 

--- a/tests/property_group_test.py
+++ b/tests/property_group_test.py
@@ -211,18 +211,12 @@ def test_property_group_errors(tmp_path):
         ):
             PropertyGroup(parent=curve)
 
-        with pytest.raises(TypeError, match="Properties must be an iterable"):
-            prop_group._validate_properties(123)  # pylint: disable=protected-access
-
         with pytest.raises(TypeError, match="Property group must be of type"):
             curve.add_data_to_group(data="bidon", property_group=123)
 
         # test error for allow delete
         with pytest.raises(TypeError, match="allow_delete must be a boolean"):
             prop_group.allow_delete = "bidon"
-
-        with pytest.raises(AttributeError, match="can't set attribute"):
-            prop_group.association = "bidon"
 
         with pytest.raises(TypeError, match="Association must be"):
             PropertyGroup(parent=curve, association=123)

--- a/tests/property_group_test.py
+++ b/tests/property_group_test.py
@@ -286,10 +286,16 @@ def test_property_group_table(tmp_path):
                 ("StrColumn",)
             )
 
-        curve.add_data(
-            {"StrColumn": {"values": ["i" for i in range(12)]}},
-            property_group="myGroup",
-        )
+        # todo: note that now, 2 properties of the same group cannot have different shapes.
+        # todo: Still, this case if possible when initialize with "properties" but not "add_properties"
+        # todo: is this an issue? Or expected behaviour?
+        with pytest.raises(
+            ValueError, match="All properties must have the same length"
+        ):
+            curve.add_data(
+                {"StrColumn": {"values": np.array(["i" for i in range(13)])}},
+                property_group="myGroup",
+            )
 
 
 def test_property_group_table_error(tmp_path):
@@ -306,6 +312,11 @@ def test_property_group_table_error(tmp_path):
         prop_group.property_table.update()  # nothing happens..
 
         assert prop_group.property_table.property_table is None
+
+        with pytest.raises(ValueError, match="Data '"):
+            prop_group.property_table._convert_names_to_uid(  # pylint: disable=protected-access
+                (uuid4(),)
+            )
 
         with pytest.raises(ValueError, match="The PropertyGroup has no property."):
             prop_group.property_table._create_empty_structured_array(  # pylint: disable=protected-access

--- a/tests/property_group_test.py
+++ b/tests/property_group_test.py
@@ -155,6 +155,16 @@ def test_create_property_group(tmp_path):
             rec_object.property_groups is None
         ), "Property_groups not properly removed."
 
+        # test for properties post assignation
+
+        prop_group = PropertyGroup(parent=rec_object, name="testGroup")
+        prop_group.properties = [
+            child for child in rec_object.children if isinstance(child, Data)
+        ]
+        assert [
+            child.uid for child in rec_object.children if isinstance(child, Data)
+        ] == prop_group.properties
+
 
 def test_property_group_errors(tmp_path):
     #  pylint: disable=too-many-locals
@@ -235,6 +245,9 @@ def test_property_group_errors(tmp_path):
 
         with pytest.raises(ValueError, match="Data 'WrongParent' parent"):
             prop_group.verify_data(test_data)
+
+        with pytest.raises(UserWarning, match="Cannot modify 'property group type'"):
+            prop_group.property_group_type = "bidon"
 
 
 def test_auto_find_association(tmp_path):

--- a/tests/property_group_test.py
+++ b/tests/property_group_test.py
@@ -256,11 +256,6 @@ def test_property_group_errors(tmp_path):
         with pytest.raises(ValueError, match="Data 'WrongParent' parent"):
             prop_group._validate_data(test_data)  # pylint: disable=protected-access
 
-        with pytest.raises(
-            AttributeError, match="can't set attribute 'property_group_type'"
-        ):
-            prop_group.property_group_type = "bidon"
-
 
 def test_auto_find_association(tmp_path):
     h5file_path = tmp_path / r"prop_group_test.geoh5"

--- a/tests/remove_root_test.py
+++ b/tests/remove_root_test.py
@@ -105,14 +105,10 @@ def test_remove_root(tmp_path: Path):
             }
         )
 
-        with pytest.raises(
-            ValueError, match="All input 'data' must have the same association"
-        ):
+        with pytest.raises(ValueError, match="Data 'DataValues2b' association"):
             points2.add_data_to_group(data2, "bidon")
 
-        with pytest.raises(
-            ValueError, match="No children data found on the parent object."
-        ):
+        with pytest.raises(ValueError, match="Data 'abs' not found in parent"):
             points2.add_data_to_group(["abs"], "bidon")
 
         points2._property_groups = None

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,27 @@
+#  Copyright (c) 2024 Mira Geoscience Ltd.
+#
+#  This file is part of geoh5py.
+#
+#  geoh5py is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  geoh5py is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from geoh5py.shared.utils import find_unique_name
+
+
+def test_find_unique_name():
+    name = "test"
+    names = ["test", "test(1)", "bidon"]
+
+    assert find_unique_name(name, names) == "test(2)"


### PR DESCRIPTION
**GEOPY-1755 - create an object to access all the data of a property group in a recarray**
add a table for property group.

I used the same way to name the tables as "drillholes_group_table"

Still, I think it could be benificial in the future to name the property "table", 
the "[...]_table" "full" (or even __call__) and the "[...]_table form name" => "from_name()" for simplification for both usages. 