### PR TITLE
DEVOPS-471: Merge windows and unix python reusable workflow in one file

### DIFF
--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -32,7 +32,7 @@ jobs:
       python-version: '3.10'
   call-workflow-pytest:
     name: Pytest
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@DEVOPS-471
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@DEVOPS-466
     with:
       package-manager: 'poetry'
       python-versions: '["3.10", "3.11", "3.12"]'

--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -39,5 +39,6 @@ jobs:
       os: '["ubuntu-latest", "windows-latest"]'
       cache-number: 1
       codecov-reference-python-version: '3.10'
+      codecov-reference-os: '["windows-latest", "ubuntu-latest"]'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -29,21 +29,32 @@ jobs:
       package-manager: 'poetry'
       app-name: 'geoh5py'
       python-version: '3.10'
-  call-workflow-pytest-on-windows:
-    name: Pytest on Windows
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_windows.yml@DEVOPS-466
+  # call-workflow-pytest-on-windows:
+  #   name: Pytest on Windows
+  #   uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_windows.yml@DEVOPS-466
+  #   with:
+  #     package-manager: 'poetry'
+  #     python-versions: '["3.10", "3.11", "3.12"]'
+  #     cache-number: 1
+  #     codecov-reference-python-version: '3.10'
+  #   secrets:
+  #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  # call-workflow-pytest-on-unix-os:
+  #   name: Pytest on Unix OS
+  #   uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_unix_os.yml@DEVOPS-466
+  #   with:
+  #     package-manager: 'poetry'
+  #     python-versions: '["3.10", "3.11", "3.12"]'
+  #     os: '["ubuntu-latest"]'
+  #     cache-number: 1
+  call-workflow-pytest:
+    name: Pytest on any OS
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@DEVOPS-471
     with:
       package-manager: 'poetry'
       python-versions: '["3.10", "3.11", "3.12"]'
+      os: '["ubuntu-latest", "windows-latest"]'
       cache-number: 1
       codecov-reference-python-version: '3.10'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  call-workflow-pytest-on-unix-os:
-    name: Pytest on Unix OS
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_unix_os.yml@DEVOPS-466
-    with:
-      package-manager: 'poetry'
-      python-versions: '["3.10", "3.11", "3.12"]'
-      os: '["ubuntu-latest"]'
-      cache-number: 1

--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -23,13 +23,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  call-workflow-static-analysis:
-    name: Static analysis
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@DEVOPS-466
-    with:
-      package-manager: 'poetry'
-      app-name: 'geoh5py'
-      python-version: '3.10'
+  # call-workflow-static-analysis:
+  #   name: Static analysis
+  #   uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@DEVOPS-466
+  #   with:
+  #     package-manager: 'poetry'
+  #     app-name: 'geoh5py'
+  #     python-version: '3.10'
   # call-workflow-pytest-on-windows:
   #   name: Pytest on Windows
   #   uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_windows.yml@DEVOPS-466

--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -16,6 +16,7 @@ on:
       - release/**
       - feature/**
       - hotfix/**
+      - DEVOPS-471 # TODO: Remove this line after DEVOPS-471 is resolved
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -9,6 +9,7 @@ on:
       - release/**
       - feature/**
       - hotfix/**
+      - DEVOPS-466 # Temporary branch for testing
   push:
     branches:
       - develop
@@ -16,40 +17,21 @@ on:
       - release/**
       - feature/**
       - hotfix/**
-      - DEVOPS-471 # TODO: Remove this line after DEVOPS-471 is resolved
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  # call-workflow-static-analysis:
-  #   name: Static analysis
-  #   uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@DEVOPS-466
-  #   with:
-  #     package-manager: 'poetry'
-  #     app-name: 'geoh5py'
-  #     python-version: '3.10'
-  # call-workflow-pytest-on-windows:
-  #   name: Pytest on Windows
-  #   uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_windows.yml@DEVOPS-466
-  #   with:
-  #     package-manager: 'poetry'
-  #     python-versions: '["3.10", "3.11", "3.12"]'
-  #     cache-number: 1
-  #     codecov-reference-python-version: '3.10'
-  #   secrets:
-  #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  # call-workflow-pytest-on-unix-os:
-  #   name: Pytest on Unix OS
-  #   uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_unix_os.yml@DEVOPS-466
-  #   with:
-  #     package-manager: 'poetry'
-  #     python-versions: '["3.10", "3.11", "3.12"]'
-  #     os: '["ubuntu-latest"]'
-  #     cache-number: 1
+  call-workflow-static-analysis:
+    name: Static analysis
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@DEVOPS-466
+    with:
+      package-manager: 'poetry'
+      app-name: 'geoh5py'
+      python-version: '3.10'
   call-workflow-pytest:
-    name: Pytest on any OS
+    name: Pytest
     uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@DEVOPS-471
     with:
       package-manager: 'poetry'


### PR DESCRIPTION
**DEVOPS-471 - Merge windows and unix python reusable workflow in one file**
⚠️ Need to modify workflow reference `DEVOPS-471` to `DEVOPS-466` when `DEVOPS-471` gonna be merge in CI-Tools