### PR TITLE
GEOPY-1733: Block model centroids not computed correctly for negative cell delimiters

### DIFF
--- a/geoh5py/objects/block_model.py
+++ b/geoh5py/objects/block_model.py
@@ -69,8 +69,9 @@ class BlockModel(GridObject):
 
         :param axis: Axis to get the centers for.
         """
-        n_cells = getattr(self, f"{axis}_cells")
-        return np.cumsum(n_cells) - n_cells / 2.0
+        out = np.cumsum(getattr(self, f"{axis}_cell_delimiters"))
+        out[2:] = out[2:] - out[:-2]
+        return out[2 - 1 :] / 2
 
     @property
     def centroids(self) -> np.ndarray:

--- a/geoh5py/objects/block_model.py
+++ b/geoh5py/objects/block_model.py
@@ -71,7 +71,7 @@ class BlockModel(GridObject):
         """
         out = np.cumsum(getattr(self, f"{axis}_cell_delimiters"))
         out[2:] = out[2:] - out[:-2]
-        return out[2 - 1 :] / 2
+        return out[1:] / 2
 
     @property
     def centroids(self) -> np.ndarray:

--- a/tests/block_model_test.py
+++ b/tests/block_model_test.py
@@ -26,6 +26,30 @@ from geoh5py.shared.utils import compare_entities
 from geoh5py.workspace import Workspace
 
 
+def test_negative_cell_delimiters_centroids(tmp_path):
+    workspace = Workspace.create(tmp_path / "test.geoh5")
+    block_model = BlockModel.create(
+        workspace,
+        name="test",
+        u_cell_delimiters=np.array([-1, 0, 1]),
+        v_cell_delimiters=np.array([-1, 0, 1]),
+        z_cell_delimiters=np.array([-3, -2, -1]),
+        origin=np.r_[0, 0, 0],
+    )
+    assert np.allclose(
+        block_model.centroids[:, 0],
+        np.array([-0.5, -0.5, 0.5, 0.5, -0.5, -0.5, 0.5, 0.5]),
+    )
+    assert np.allclose(
+        block_model.centroids[:, 1],
+        np.array([-0.5, -0.5, -0.5, -0.5, 0.5, 0.5, 0.5, 0.5]),
+    )
+    assert np.allclose(
+        block_model.centroids[:, 2],
+        np.array([-2.5, -1.5, -2.5, -1.5, -2.5, -1.5, -2.5, -1.5]),
+    )
+
+
 def test_create_block_model_data(tmp_path):
     name = "MyTestBlockModel"
     h5file_path = tmp_path / r"block_model.geoh5"


### PR DESCRIPTION
**GEOPY-1733 - Block model centroids not computed correctly for negative cell delimiters**
