### PR TITLE
GEOPY-1797: wrong minimum Python version in geoh5py doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,10 @@ Installation
 ^^^^^^^^^^^^
 **geoh5py** is currently written for Python 3.10 or higher, and depends on `NumPy <https://numpy.org/>`_ and
 `h5py <https://www.h5py.org/>`_. Users will likely want to also make use of advanced processing
-techniques made available under the python ecosystem. We therefore recommend installing
-`Miniforge <https://github.com/conda-forge/miniforge#download>`_ `(Windows x86_64) <https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe>`_ to handle the various packages.
+techniques made available under the python ecosystem. We therefore recommend installing a **Conda** distribution
+such as `miniforge`_ to handle the various packages.
+
+.. _miniforge: https://github.com/conda-forge/miniforge
 
 Install **geoh5py** from PyPI::
 

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ See also documentation for the `geoh5 file format`_.
 
 Installation
 ^^^^^^^^^^^^
-**geoh5py** is currently written for Python 3.7 or higher, and depends on `NumPy <https://numpy.org/>`_ and
+**geoh5py** is currently written for Python 3.10 or higher, and depends on `NumPy <https://numpy.org/>`_ and
 `h5py <https://www.h5py.org/>`_. Users will likely want to also make use of advanced processing
 techniques made available under the python ecosystem. We therefore recommend installing
 `Miniforge <https://github.com/conda-forge/miniforge#download>`_ `(Windows x86_64) <https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe>`_ to handle the various packages.

--- a/docs/content/installation.rst
+++ b/docs/content/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-**geoh5py** is currently written for Python 3.9 or higher, and depends on `NumPy <https://numpy.org/>`_ and
+**geoh5py** is currently written for Python 3.10 or higher, and depends on `NumPy <https://numpy.org/>`_ and
 `h5py <https://www.h5py.org/>`_.
 
 

--- a/docs/content/release_notes.rst
+++ b/docs/content/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 Release 0.10.0 (2024-10-31)
 ---------------------------
 
+- Drop support for Python 3.9
 - GEOPY-1602: Major refactor of class instantiation and inheritance
     - Entity type passed as a keyword argument to the constructor.
     - Deprecate property 'default_type_uid' in favour of class attribute '_TYPE_UID'.

--- a/package.rst
+++ b/package.rst
@@ -9,8 +9,7 @@ capabilities of `Geoscience ANALYST <https://mirageoscience.com/mining-industry-
 
 Installation
 ^^^^^^^^^^^^
-**geoh5py** is currently written for Python 3.9 or higher, and depends on `NumPy <https://numpy.org/>`_ and
-`h5py <https://www.h5py.org/>`_.
+**geoh5py** depends on `NumPy <https://numpy.org/>`_ and `h5py <https://www.h5py.org/>`_.
 
 .. note:: Users will likely want to take advantage of other packages available in the Python ecosystem.
     We therefore recommend using `Miniforge <https://github.com/conda-forge/miniforge#download>`_ `(Windows x86_64) <https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe>`_


### PR DESCRIPTION
**GEOPY-1797 - wrong minimum Python version in geoh5py doc**
