### PR TITLE
GEOPY-1798: fail to open workspace due to data_type mapping epxected to be "cdf"

### DIFF
--- a/geoh5py/data/data_type.py
+++ b/geoh5py/data/data_type.py
@@ -33,7 +33,14 @@ if TYPE_CHECKING:
     from .data import Data  # noqa: F401
 
 
-ColorMapping = Literal["linear", "equal_area", "logarithmic", "cdf", "missing"]
+ColorMapping = Literal[
+    "linear",
+    "equal_area",
+    "logarithmic",
+    "cdf",
+    "cumulative_distribution_function",
+    "missing",
+]
 
 
 class DataType(EntityType):


### PR DESCRIPTION
**GEOPY-1798 - fail to open workspace due to data_type mapping epxected to be "cdf"**
