### PR TITLE
GEOPY-1815: Can't read DrillholeGroup with Strike/dip property_group_type

### DIFF
--- a/geoh5py/shared/concatenation/concatenator.py
+++ b/geoh5py/shared/concatenation/concatenator.py
@@ -716,6 +716,8 @@ class Concatenator(Group):  # pylint: disable=too-many-public-methods
                 if (
                     property_group is not None
                     and property_group.name not in drillholes_tables
+                    and property_group.property_group_type
+                    in ["Depth table", "Interval table"]
                 ):
                     drillholes_tables[property_group.name] = DrillholesGroupTable(
                         self, property_group.name

--- a/geoh5py/shared/concatenation/concatenator.py
+++ b/geoh5py/shared/concatenation/concatenator.py
@@ -716,7 +716,7 @@ class Concatenator(Group):  # pylint: disable=too-many-public-methods
                 if (
                     property_group is not None
                     and property_group.name not in drillholes_tables
-                    and property_group.property_group_type
+                    and getattr(property_group, "property_group_type", None)
                     in ["Depth table", "Interval table"]
                 ):
                     drillholes_tables[property_group.name] = DrillholesGroupTable(


### PR DESCRIPTION
**GEOPY-1815 - Can't read DrillholeGroup with Strike/dip property_group_type**
avoid non compatible property_group to be present in drillholes-table