### PR TITLE
DEVOPS-552: relabel package publish tasks

### DIFF
--- a/.github/workflows/python_deploy_dev.yml
+++ b/.github/workflows/python_deploy_dev.yml
@@ -17,7 +17,7 @@ jobs:
       JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
       JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
   call-workflow-pypi-publish:
-    name: Publish development pypi package on JFrog Artifactory
+    name: Publish development pypi package (JFrog Artifactory and TestPyPI)
     uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-publish_pypi_package.yml@main
     with:
       package-manager: 'poetry'

--- a/.github/workflows/python_deploy_prod.yml
+++ b/.github/workflows/python_deploy_prod.yml
@@ -16,7 +16,7 @@ jobs:
       JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
       JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
   call-workflow-pypi-publish:
-    name: Publish development pypi package on JFrog Artifactory
+    name: Publish production pypi package (JFrog Artifactory and  PyPI)
     uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-publish_pypi_package.yml@main
     with:
       package-manager: 'poetry'


### PR DESCRIPTION
**DEVOPS-552 - Correct Pypi url in reusable-python-publish_pip_package.yml**
**relabel package publish tasks**

in scope of work for DEVOPS-552