### PR TITLE
GEOPY-1840: Enforce reference data type shared between the tx_id_property of receiver and complement (transmitter, base station)

### DIFF
--- a/geoh5py/objects/surveys/electromagnetics/base.py
+++ b/geoh5py/objects/surveys/electromagnetics/base.py
@@ -466,6 +466,11 @@ class BaseEMSurvey(ObjectBase, ABC):  # pylint: disable=too-many-public-methods
         if receivers.tx_id_property is not None:
             self.edit_em_metadata({"Tx ID property": receivers.tx_id_property.uid})
 
+            if isinstance(
+                self.tx_id_property, ReferencedData | IntegerData
+            ) and isinstance(receivers.tx_id_property, ReferencedData | IntegerData):
+                self.tx_id_property.entity_type = receivers.tx_id_property.entity_type
+
         self._receivers = receivers
         self.edit_em_metadata({"Receivers": receivers.uid})
 
@@ -512,6 +517,12 @@ class BaseEMSurvey(ObjectBase, ABC):  # pylint: disable=too-many-public-methods
             self.edit_em_metadata(
                 {"Tx ID tx property": transmitters.tx_id_property.uid}
             )
+            if isinstance(
+                self.tx_id_property, ReferencedData | IntegerData
+            ) and isinstance(transmitters.tx_id_property, ReferencedData | IntegerData):
+                self.tx_id_property.entity_type = (
+                    transmitters.tx_id_property.entity_type
+                )
 
         self._transmitters = transmitters
         self.edit_em_metadata({"Transmitters": transmitters.uid})

--- a/geoh5py/objects/surveys/electromagnetics/tipper.py
+++ b/geoh5py/objects/surveys/electromagnetics/tipper.py
@@ -22,6 +22,7 @@ import uuid
 
 import numpy as np
 
+from geoh5py.data import IntegerData, ReferencedData
 from geoh5py.objects.curve import Curve
 from geoh5py.objects.points import Points
 
@@ -84,6 +85,11 @@ class TipperSurvey(FEMSurvey):
 
         if base.tx_id_property is not None:
             self.edit_em_metadata({"Tx ID tx property": base.tx_id_property.uid})
+
+            if isinstance(
+                self.tx_id_property, ReferencedData | IntegerData
+            ) and isinstance(base.tx_id_property, ReferencedData | IntegerData):
+                self.tx_id_property.entity_type = base.tx_id_property.entity_type
 
         self._base_stations = base
         self.edit_em_metadata({"Base stations": base.uid})

--- a/tests/survey_airborne_tem_test.py
+++ b/tests/survey_airborne_tem_test.py
@@ -76,7 +76,6 @@ def test_create_survey_airborne_tem(tmp_path):
         transmitters.transmitters = receivers
 
     receivers.transmitters = transmitters
-
     with pytest.raises(TypeError, match="Input 'loop_radius' must be of type 'float'"):
         receivers.loop_radius = "123"
 

--- a/tests/survey_tipper_test.py
+++ b/tests/survey_tipper_test.py
@@ -68,6 +68,9 @@ def test_create_survey_tipper(tmp_path):
 
     receivers.base_stations = base_stations
 
+    assert (
+        receivers.tx_id_property.entity_type == base_stations.tx_id_property.entity_type
+    )
     with pytest.raises(ValueError, match="Mask must be an array of shape"):
         receivers.copy(mask=np.r_[1, 2, 3])
 


### PR DESCRIPTION
**GEOPY-1840 - Enforce reference data type shared between the tx_id_property of receiver and complement (transmitter, base station)**
