### PR TITLE
DEVOPS-559: Limit dependabot scan to production dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
     schedule:
       interval: "monthly"
     target-branch: "develop"
+    allow:
+      - dependency-type: "production" # Disable when runtime dependencies vulnerabilities are mostly address


### PR DESCRIPTION
**DEVOPS-559 - Python packages: until vulnerability on runtime dependencies are mostly address, tell dependabot not to scan dev dependencies**
