### PR TITLE
GEOPY-1813: Change typing for input PropertyGroup.properties to list[Data] | list[UUID] | list[str] instead list[Data | UUID | str]

### DIFF
--- a/geoh5py/groups/property_group.py
+++ b/geoh5py/groups/property_group.py
@@ -68,7 +68,7 @@ class PropertyGroup:
         on_file: bool = False,
         uid: UUID | None = None,
         property_group_type: GroupTypeEnum | str = GroupTypeEnum.SIMPLE,
-        properties: list[UUID | Data | str] | None = None,
+        properties: Sequence[UUID | Data | str] | None = None,
         **_,
     ):
         self._parent: ObjectBase = self._validate_parent(parent)
@@ -88,7 +88,7 @@ class PropertyGroup:
         self.parent.workspace.register(self)
 
     def _initialize_properties(
-        self, properties: str | UUID | Data | list[UUID | str | Data] | None
+        self, properties: str | UUID | Data | Sequence[UUID | str | Data] | None
     ) -> list[Data] | None:
         """
         Initialize the properties list.
@@ -211,7 +211,7 @@ class PropertyGroup:
 
         return [data.uid for data in data_list_]
 
-    def add_properties(self, data: str | Data | list[str | Data | UUID] | UUID):
+    def add_properties(self, data: str | Data | Sequence[str | Data | UUID] | UUID):
         """
         Add data to properties.
 
@@ -223,11 +223,11 @@ class PropertyGroup:
                 f"Cannot add properties to '{self._property_group_type}' property group type."
             )
 
-        if not isinstance(data, list):
+        if isinstance(data, (str, UUID, Data)):
             data = [data]
 
         properties = self._validate_properties(
-            data if self.properties is None else self.properties + data
+            data if self.properties is None else self.properties + list(data)
         )
 
         if properties:
@@ -357,7 +357,7 @@ class PropertyGroup:
         """
         return self._property_group_type
 
-    def remove_properties(self, data: str | Data | list[str | Data | UUID] | UUID):
+    def remove_properties(self, data: str | Data | Sequence[str | Data | UUID] | UUID):
         """
         Remove data from the properties.
 
@@ -372,7 +372,7 @@ class PropertyGroup:
         if self.properties is None:
             return
 
-        if not isinstance(data, list):
+        if isinstance(data, (str, UUID, Data)):
             data = [data]
 
         properties = self.properties

--- a/geoh5py/shared/concatenation/property_group.py
+++ b/geoh5py/shared/concatenation/property_group.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -152,7 +153,7 @@ class ConcatenatedPropertyGroup(PropertyGroup):
         parent.workspace.add_or_update_property_group(self)
 
     def _clear_data_list(
-        self, data: str | Data | list[str | Data | UUID] | UUID
+        self, data: str | Data | Sequence[str | Data | UUID] | UUID
     ) -> list[str | Data | UUID]:
         """
         Clear the data list of any data that is a depth or from/to data.
@@ -161,7 +162,7 @@ class ConcatenatedPropertyGroup(PropertyGroup):
 
         :return: List of data with depth and from/to data removed.
         """
-        if not isinstance(data, (list, tuple)):
+        if isinstance(data, (str, Data, UUID)):
             data = [data]
 
         # avoid suppressing depth and from-to directly
@@ -203,7 +204,7 @@ class ConcatenatedPropertyGroup(PropertyGroup):
             self._properties.remove(self.from_.uid)
             self.parent.remove_children([self.from_, self])
 
-    def remove_properties(self, data: str | Data | list[str | Data | UUID] | UUID):
+    def remove_properties(self, data: str | Data | Sequence[str | Data | UUID] | UUID):
         """
         Remove data from the properties.
 


### PR DESCRIPTION
**GEOPY-1813 - Change typing for input PropertyGroup.properties to list[Data] | list[UUID] | list[str] instead list[Data | UUID | str]**
change the list type by Sequence as mypy don't like list