### PR TITLE
GEOPY-1860: do not include top level files in wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,12 +31,12 @@ classifiers = [
 exclude = ["geoh5py/handlers/*", "geoh5py/interfaces/*"]
 
 include = [
-    { path = "COPYING", format = ["sdist", "wheel"] },
-    { path = "COPYING.LESSER", format = ["sdist", "wheel"] },
-    { path = "LICENSE", format = ["sdist", "wheel"] },
-    { path = "README.rst", format = ["sdist", "wheel"] },
-    { path = "THIRD_PARTY_SOFTWARE.rst", format = ["sdist", "wheel"] },
-    { path = "docs/**/THIRD_PARTY_SOFTWARE.rst", format = ["sdist", "wheel"] },
+    { path = "COPYING" },
+    { path = "COPYING.LESSER" },
+    { path = "LICENSE" },
+    { path = "README.rst" },
+    { path = "THIRD_PARTY_SOFTWARE.rst" },
+    { path = "docs/**/THIRD_PARTY_SOFTWARE.rst" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
**GEOPY-1860 - pyproject.toml must not include top level files in wheels**
According to Poetry doc:
When a wheel is installed, its includes are unpacked straight into the site-packages directory. Pay attention to include top level files and directories with common names like CHANGELOG.md, LICENSE, tests or docs only in sdists and not in wheels.