### PR TITLE
GEOPY-1932: Desurveying can produce a divide by zero warning with some paths

### DIFF
--- a/geoh5py/objects/drillhole.py
+++ b/geoh5py/objects/drillhole.py
@@ -811,11 +811,9 @@ class Drillhole(Points):
         norm[norm == 0.0] = INFINITE_RADIUS
         tangential /= norm[:, None]
         alpha = np.abs(0.5 * np.pi - np.arctan2(dot, vr))
+        alpha[alpha == 0.0] = INFINITE_RADIUS**-1.0
         delta_depth = np.diff(full_survey[:, 0])
         radius = delta_depth / alpha
-
-        radius[alpha == 0.0] = delta_depth[alpha == 0.0] * INFINITE_RADIUS
-        alpha[alpha == 0.0] = delta_depth[alpha == 0.0] / radius[alpha == 0.0]
 
         intervals = {
             "depths": np.r_[full_survey[:, 0]],


### PR DESCRIPTION
**GEOPY-1932 - Desurveying can produce a divide by zero warning with some paths**
(cherry picked from commit 0e775c829f181c94c93628cc902dd554ea089e8c)