### PR TITLE
GEOPY-1987: Error from cmd.exe printed if h5repack is not found

### DIFF
--- a/geoh5py/workspace/workspace.py
+++ b/geoh5py/workspace/workspace.py
@@ -32,6 +32,7 @@ from contextlib import AbstractContextManager, contextmanager
 from gc import collect
 from getpass import getuser
 from io import BytesIO
+from logging import getLogger
 from pathlib import Path
 from shutil import copy, move
 from subprocess import CalledProcessError
@@ -75,6 +76,8 @@ from ..shared.utils import (
     str2uuid,
 )
 
+
+logger = getLogger(__name__)
 
 NETWORK_DRIVES = [
     "Egnyte Connect",
@@ -221,16 +224,15 @@ class Workspace(AbstractContextManager):
             temp_file = Path(tempfile.gettempdir()) / Path(self._h5file).name
             try:
                 subprocess.run(
-                    f'h5repack --native "{self._h5file}" "{temp_file}"',
+                    ["h5repack", "--native", str(self._h5file), str(temp_file)],
                     check=True,
-                    shell=True,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
+                    capture_output=True,
+                    encoding="utf8",
                 )
-                Path(self._h5file).unlink()
-                move(temp_file, self._h5file, copy)
-            except CalledProcessError:
+            except FileNotFoundError:
                 pass
+            except CalledProcessError as process_error:
+                logger.error("%s\n%s", process_error.stdout, process_error.stderr)
 
             self.repack = False
 

--- a/geoh5py/workspace/workspace.py
+++ b/geoh5py/workspace/workspace.py
@@ -229,6 +229,8 @@ class Workspace(AbstractContextManager):
                     capture_output=True,
                     encoding="utf8",
                 )
+                Path(self._h5file).unlink()
+                move(temp_file, self._h5file, copy)
             except FileNotFoundError:
                 pass
             except CalledProcessError as process_error:

--- a/geoh5py/workspace/workspace.py
+++ b/geoh5py/workspace/workspace.py
@@ -225,6 +225,7 @@ class Workspace(AbstractContextManager):
                     check=True,
                     shell=True,
                     stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
                 )
                 Path(self._h5file).unlink()
                 move(temp_file, self._h5file, copy)


### PR DESCRIPTION
**GEOPY-1987 - Error from cmd.exe printed if h5repack is not found**
