### PR TITLE
GEOPY-2096: ChoiceList parameters are converted to list when value is a string.

### DIFF
--- a/geoh5py/ui_json/forms.py
+++ b/geoh5py/ui_json/forms.py
@@ -164,6 +164,20 @@ class ChoiceForm(BaseForm):
     Choice list uijson form.
     """
 
+    value: str
+    choice_list: list[str]
+
+    @model_validator(mode="after")
+    def valid_choice(self):
+        if self.value not in self.choice_list:
+            raise ValueError(f"Provided value: '{self.value}' is not a valid choice.")
+
+        return self
+
+
+class MultiChoiceForm(BaseForm):
+    """Multi-choice list uijson form."""
+
     value: list[str]
     choice_list: list[str]
     multi_select: bool = False
@@ -173,12 +187,6 @@ class ChoiceForm(BaseForm):
     def to_list(cls, value):
         if not isinstance(value, list):
             value = [value]
-        return value
-
-    @field_serializer("value", when_used="json")
-    def string_if_single(self, value):
-        if len(value) == 1:
-            value = value[0]
         return value
 
     @model_validator(mode="after")

--- a/tests/ui_json/forms_test.py
+++ b/tests/ui_json/forms_test.py
@@ -38,6 +38,7 @@ from geoh5py.ui_json.forms import (
     FileForm,
     FloatForm,
     IntegerForm,
+    MultiChoiceForm,
     ObjectForm,
     StringForm,
 )
@@ -145,19 +146,25 @@ def test_float_form():
 def test_choice_form():
     form = ChoiceForm(label="name", value="test", choice_list=["test"])
     assert form.label == "name"
-    assert form.value == ["test"]
+    assert form.value == "test"
     assert form.choice_list == ["test"]
-    assert not form.multi_select
     assert '"value":"test"' in form.json_string
-    msg = r"Provided value\(s\): \['nope'\] are not valid choices"
+    msg = r"Provided value: 'nope' is not a valid choice"
     with pytest.raises(ValidationError, match=msg):
         _ = ChoiceForm(label="name", value="nope", choice_list=["test"])
 
-    form = ChoiceForm(
-        label="name", value=["test", "other"], choice_list=["test", "other"]
+
+def test_multi_choice_form():
+    form = MultiChoiceForm(
+        label="names", value=["test", "other"], choice_list=["test", "other", "another"]
     )
     assert form.value == ["test", "other"]
+    assert form.choice_list == ["test", "other", "another"]
     assert '"value":["test","other"]' in form.json_string
+
+    form = MultiChoiceForm(label="names", value="test", choice_list=["test", "other"])
+    assert form.value == ["test"]
+    assert '"value":["test"]' in form.json_string
 
 
 def test_file_form(tmp_path):


### PR DESCRIPTION
**GEOPY-2096 - ChoiceList parameters are converted to list when value is a string.**
…from the regular ChoiceForm.