### PR TITLE
GEOPY-2301: The fxmean attached to a referenced data is getting always the same name

### DIFF
--- a/geoh5py/data/referenced_data.py
+++ b/geoh5py/data/referenced_data.py
@@ -162,12 +162,13 @@ class ReferencedData(IntegerData):
         del self.data_maps[name]
         self.data_maps = self._data_maps
 
-    def add_data_map(self, name: str, values: np.ndarray | dict):
+    def add_data_map(self, name: str, values: np.ndarray | dict, public: bool = True):
         """
         Add a data map to the value map.
 
         :param name: The name of the data map.
         :param values: The data map to add.
+        :param public: Whether the data map should be public.
         """
-        data = self.parent.add_data_map(self, name, values)
+        data = self.parent.add_data_map(self, name, values, public)
         return data

--- a/geoh5py/objects/object_base.py
+++ b/geoh5py/objects/object_base.py
@@ -240,7 +240,7 @@ class ObjectBase(EntityContainer):
         return data_objects
 
     def add_data_map(
-        self, data: ReferencedData, name: str, values: dict
+        self, data: ReferencedData, name: str, values: dict, public: bool = True
     ) -> GeometricDataConstants:
         """
         Add a data map to the reference data under the object.
@@ -248,11 +248,14 @@ class ObjectBase(EntityContainer):
         :param data: The referenced data to add the map to.
         :param name: The name of the data map.
         :param values: The values to add to the data map.
+        :param public: Whether the data map is public or not.
         """
         data_maps = data.data_maps or {}
 
         names = [
-            child.name for child in self.children if isinstance(child, ReferencedData)
+            child.name
+            for child in self.children
+            if isinstance(child, (ReferencedData, GeometricDataConstants))
         ]
         name = find_unique_name(name, names)
 
@@ -283,6 +286,7 @@ class ObjectBase(EntityContainer):
                     name: {
                         "association": data.association,
                         "entity_type": data_type,
+                        "public": public,
                     }
                 }
             ),

--- a/geoh5py/objects/object_base.py
+++ b/geoh5py/objects/object_base.py
@@ -255,7 +255,7 @@ class ObjectBase(EntityContainer):
         names = [
             child.name
             for child in self.children
-            if isinstance(child,  GeometricDataConstants)
+            if isinstance(child, GeometricDataConstants)
         ]
         name = find_unique_name(name, names)
 

--- a/geoh5py/objects/object_base.py
+++ b/geoh5py/objects/object_base.py
@@ -255,7 +255,7 @@ class ObjectBase(EntityContainer):
         names = [
             child.name
             for child in self.children
-            if isinstance(child, (ReferencedData, GeometricDataConstants))
+            if isinstance(child,  GeometricDataConstants)
         ]
         name = find_unique_name(name, names)
 

--- a/tests/reference_data_test.py
+++ b/tests/reference_data_test.py
@@ -153,6 +153,9 @@ def test_add_data_map(tmp_path):
 
         data.add_data_map("test2", data_map)
 
+        # test duplicate
+        data.add_data_map("test2", data_map, public=False)
+
         assert isinstance(data.data_maps["test"], GeometricDataConstants)
 
     with Workspace(h5file_path) as workspace:
@@ -172,6 +175,17 @@ def test_add_data_map(tmp_path):
         np.testing.assert_array_almost_equal(
             np.asarray(list(geo_data.entity_type.value_map().values()), dtype=float),
             data_map[:, 1],
+        )
+
+        geo_data_2 = rec_data.data_maps["test2(1)"]
+        assert geo_data_2.entity_type.value_map.name == "test2(1)"
+
+        assert geo_data.public == 1
+        assert geo_data_2.public == 0
+
+        assert np.array_equal(
+            np.asarray(list(geo_data.entity_type.value_map().values()), dtype=float),
+            np.asarray(list(geo_data_2.entity_type.value_map().values()), dtype=float),
         )
 
 

--- a/tests/text_data_test.py
+++ b/tests/text_data_test.py
@@ -155,3 +155,37 @@ def test_create_byte_text_data(tmp_path: Path):
 
             word.values = np.array([b"b word"])[0]
             assert word.values == "b word"
+
+
+def test_create_one_text_data(tmp_path: Path):
+    """
+    Would be great to visualize text in GA, if a text object contains 1 text only
+    """
+    name = "MyTestPointset"
+
+    # Generate a random cloud of points with reference values
+    n_data = 12
+
+    h5file_path = tmp_path / r"testTextData.geoh5"
+
+    with Workspace.create(h5file_path) as workspace:
+        points = Points.create(
+            workspace,
+            vertices=np.random.randn(n_data, 3),
+            name=name,
+            allow_move=False,
+        )
+
+        _ = points.add_data(
+            {
+                "DataValues": {
+                    "type": "text",
+                    "values": "considering only a text",
+                }
+            }
+        )
+
+    # todo: text cannot be visualize in GA, but could be printed in "DataColour"!
+    with Workspace(h5file_path).open("r") as workspace:
+        rec_data = workspace.get_entity("DataValues")[0]
+        assert "considering only a text" == rec_data.values


### PR DESCRIPTION
**GEOPY-2301 - The fxmean attached to a referenced data is getting always the same name**
data_maps now  increment names
can be made public/private (default True => actual behavious)

tested.

I also add a text test to show you what I would like to do with petro-lingo. But we cannot visualize text data (when containing only 1 text) in GA...