### PR TITLE
GEOPY-2543: remove irrelevant external links from the introduction on ui.json in geoh5py doc

### DIFF
--- a/docs/content/uijson_format/index.rst
+++ b/docs/content/uijson_format/index.rst
@@ -9,9 +9,3 @@ input parameters used in the UI, and pass those parameters to an accompanying py
 .. figure:: ./images/drag_drop.gif
         :align: center
         :width: 800
-
-
-External Links
-^^^^^^^^^^^^^^
-- `JSON Schema <https://json-schema.org/specification.html>`_
-- `Universally Unique IDentifier (UUID) <https://en.wikipedia.org/wiki/Universally_unique_identifier>`_


### PR DESCRIPTION
**GEOPY-2543 - remove irrelevant external links from the introduction on ui.json in geoh5py doc**
