### PR TITLE
DEVOPS-917: fix permission to publish to advanced security

### DIFF
--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -27,6 +27,7 @@ jobs:
   call-workflow-zizmor:
     name: Zizmor analysis
     permissions:
+      security-events: write
       contents: read
       actions: read
     uses: MiraGeoscience/CI-tools/.github/workflows/reusable-zizmor-security.yml@main


### PR DESCRIPTION
**DEVOPS-917 - remove security-devops-action checks**
