### PR TITLE
DEVOPS-917: test change for zizmor on CI-tools

### DIFF
--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -30,6 +30,6 @@ jobs:
       security-events: write
       contents: read
       actions: read
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-zizmor-security.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-zizmor-security.yml@DEVOPS-917
     with:
       advanced_security: true


### PR DESCRIPTION
**DEVOPS-917 - remove security-devops-action checks**
