### PR TITLE
GEOPY-2786: add a mthode to access the reshaped values in geoh5py for 2d grid and 3dgrid

### DIFF
--- a/geoh5py/objects/block_model.py
+++ b/geoh5py/objects/block_model.py
@@ -131,8 +131,9 @@ class BlockModel(GridObject):
         """
         Get the values of a data entity as a 3D array with the same shape as the grid.
 
-        The values are shaped as (n_z, n_u, n_v) to be consistent
-        with the Fortran ordering of the data in the file.
+        Data values are stored under the hood as a flatten array in Fortran order;
+        first, the values are reshaped to the grid shape with Fortran order,
+        then transposed to match the (n_v, n_u, n_z) shape.
 
         :param data: The data to get the values from.
 
@@ -144,7 +145,9 @@ class BlockModel(GridObject):
             else self._get_data_to_reshape(data).values
         )
 
-        return values.reshape((self.shape[2], self.shape[0], self.shape[1]), order="F")
+        return values.reshape(
+            (self.shape[2], self.shape[0], self.shape[1]), order="F"
+        ).transpose(2, 1, 0)
 
     @property
     def u_cell_delimiters(self) -> np.ndarray:

--- a/geoh5py/objects/block_model.py
+++ b/geoh5py/objects/block_model.py
@@ -24,6 +24,7 @@ import uuid
 
 import numpy as np
 
+from ..data import Data
 from ..shared.utils import xy_rotation_matrix
 from .grid_object import GridObject
 
@@ -123,6 +124,18 @@ class BlockModel(GridObject):
         Number of cells along the u, v and z-axis
         """
         return self.u_cells.shape[0], self.v_cells.shape[0], self.z_cells.shape[0]
+
+    def shaped_data_values(self, data: str | uuid.UUID | Data) -> np.ndarray:
+        """
+        Get the values of a data entity as a 2D array with the same shape as the grid.
+
+        :param data: The data to get the values from.
+
+        :return: The shaped values of the data entity.
+        """
+        return self._get_unique_data(data).values.reshape(
+            (self.shape[2], self.shape[0], self.shape[1]), order="F"
+        )
 
     @property
     def u_cell_delimiters(self) -> np.ndarray:

--- a/geoh5py/objects/block_model.py
+++ b/geoh5py/objects/block_model.py
@@ -127,7 +127,7 @@ class BlockModel(GridObject):
 
     def shaped_data_values(self, data: str | uuid.UUID | Data) -> np.ndarray:
         """
-        Get the values of a data entity as a 2D array with the same shape as the grid.
+        Get the values of a data entity as a 3D array with the same shape as the grid.
 
         :param data: The data to get the values from.
 

--- a/geoh5py/objects/block_model.py
+++ b/geoh5py/objects/block_model.py
@@ -125,17 +125,26 @@ class BlockModel(GridObject):
         """
         return self.u_cells.shape[0], self.v_cells.shape[0], self.z_cells.shape[0]
 
-    def shaped_data_values(self, data: str | uuid.UUID | Data) -> np.ndarray:
+    def shaped_data_values(
+        self, data: str | uuid.UUID | Data | np.ndarray
+    ) -> np.ndarray:
         """
         Get the values of a data entity as a 3D array with the same shape as the grid.
+
+        The values are shaped as (n_z, n_u, n_v) to be consistent
+        with the Fortran ordering of the data in the file.
 
         :param data: The data to get the values from.
 
         :return: The shaped values of the data entity.
         """
-        return self._get_unique_data(data).values.reshape(
-            (self.shape[2], self.shape[0], self.shape[1]), order="F"
+        values = (
+            data
+            if isinstance(data, np.ndarray)
+            else self._get_data_to_reshape(data).values
         )
+
+        return values.reshape((self.shape[2], self.shape[0], self.shape[1]), order="F")
 
     @property
     def u_cell_delimiters(self) -> np.ndarray:

--- a/geoh5py/objects/grid2d.py
+++ b/geoh5py/objects/grid2d.py
@@ -25,6 +25,7 @@ from numbers import Real
 
 import numpy as np
 
+from ..data import Data
 from ..objects import GeoImage
 from ..shared.conversion import Grid2DConversion
 from ..shared.utils import mask_by_extent, xy_rotation_matrix, yz_rotation_matrix
@@ -246,6 +247,18 @@ class Grid2D(GridObject):
         Number of cells along the u and v-axis.
         """
         return self.u_count, self.v_count
+
+    def shaped_data_values(self, data: str | uuid.UUID | Data) -> np.ndarray:
+        """
+        Get the values of a data entity as a 2D array with the same shape as the grid.
+
+        :param data: The data to get the values from.
+
+        :return: The shaped values of the data entity.
+        """
+        return self._get_unique_data(data).values.reshape(self.v_count, self.u_count)[
+            ::-1
+        ]
 
     @property
     def u_cell_size(self) -> float:

--- a/geoh5py/objects/grid2d.py
+++ b/geoh5py/objects/grid2d.py
@@ -264,7 +264,7 @@ class Grid2D(GridObject):
             else self._get_data_to_reshape(data).values
         )
 
-        return values.reshape(self.v_count, self.u_count)[::-1]
+        return values.reshape(self.v_count, self.u_count)
 
     @property
     def u_cell_size(self) -> float:

--- a/geoh5py/objects/grid2d.py
+++ b/geoh5py/objects/grid2d.py
@@ -248,7 +248,9 @@ class Grid2D(GridObject):
         """
         return self.u_count, self.v_count
 
-    def shaped_data_values(self, data: str | uuid.UUID | Data) -> np.ndarray:
+    def shaped_data_values(
+        self, data: str | uuid.UUID | Data | np.ndarray
+    ) -> np.ndarray:
         """
         Get the values of a data entity as a 2D array with the same shape as the grid.
 
@@ -256,9 +258,13 @@ class Grid2D(GridObject):
 
         :return: The shaped values of the data entity.
         """
-        return self._get_unique_data(data).values.reshape(self.v_count, self.u_count)[
-            ::-1
-        ]
+        values = (
+            data
+            if isinstance(data, np.ndarray)
+            else self._get_data_to_reshape(data).values
+        )
+
+        return values.reshape(self.v_count, self.u_count)[::-1]
 
     @property
     def u_cell_size(self) -> float:

--- a/geoh5py/objects/grid_object.py
+++ b/geoh5py/objects/grid_object.py
@@ -26,7 +26,7 @@ from numbers import Real
 
 import numpy as np
 
-from geoh5py.data import Data
+from geoh5py.data import Data, DataAssociationEnum
 
 from .object_base import ObjectBase
 
@@ -166,25 +166,25 @@ class GridObject(ObjectBase, ABC):
 
     def _get_unique_data(self, data: str | uuid.UUID | Data) -> Data:
         """
-        Get the values of a data entity as a 2D array with the same shape as the grid.
+        Get a unique data entity with association 'CELL' from the data name, uid or object.
 
         :param data: The data to get the values from.
 
-        :return: The shaped values of the data entity.
+        :return: The unique data.
         """
         if not isinstance(data, Data):
             data_list = self.get_data(data)
 
             if len(data_list) == 0:
-                raise ValueError(f"No data '{data_list}' found.")
+                raise ValueError(f"No data '{data}' found.")
             if len(data_list) > 1:
                 raise ValueError(
-                    f"Multiple data '{data_list}' found. Please specify a unique data name or uid."
+                    f"Multiple data '{data}' found. Please specify a unique data name or uid."
                 )
 
             data = data_list[0]
 
-        if data.association != "CELL":
+        if data.association != DataAssociationEnum.CELL:
             raise ValueError(
                 f"Data '{data.name}' has association '{data.association}'"
                 ", expected 'CELL'."

--- a/geoh5py/objects/grid_object.py
+++ b/geoh5py/objects/grid_object.py
@@ -164,9 +164,13 @@ class GridObject(ObjectBase, ABC):
 
         return mask
 
-    def _get_unique_data(self, data: str | uuid.UUID | Data) -> Data:
+    def _get_data_to_reshape(self, data: str | uuid.UUID | Data) -> Data:
         """
         Get a unique data entity with association 'CELL' from the data name, uid or object.
+
+        :raises ValueError: if no data are found.
+        :raises ValueError: if multiple data are found.
+        :raises ValueError: if the data association is not 'CELL'.
 
         :param data: The data to get the values from.
 

--- a/geoh5py/objects/grid_object.py
+++ b/geoh5py/objects/grid_object.py
@@ -20,10 +20,13 @@
 
 from __future__ import annotations
 
+import uuid
 from abc import ABC, abstractmethod
 from numbers import Real
 
 import numpy as np
+
+from geoh5py.data import Data
 
 from .object_base import ObjectBase
 
@@ -160,3 +163,30 @@ class GridObject(ObjectBase, ABC):
             )
 
         return mask
+
+    def _get_unique_data(self, data: str | uuid.UUID | Data) -> Data:
+        """
+        Get the values of a data entity as a 2D array with the same shape as the grid.
+
+        :param data: The data to get the values from.
+
+        :return: The shaped values of the data entity.
+        """
+        if not isinstance(data, Data):
+            data_list = self.get_data(data)
+
+            if len(data_list) == 0:
+                raise ValueError(f"No data '{data_list}' found.")
+            if len(data_list) > 1:
+                raise ValueError(
+                    f"Multiple data '{data_list}' found. Please specify a unique data name or uid."
+                )
+
+            data = data_list[0]
+
+        if data.association != "CELL":
+            raise ValueError(
+                f"Data '{data.name}' has association '{data.association}'"
+                ", expected 'CELL'."
+            )
+        return data

--- a/tests/block_model_test.py
+++ b/tests/block_model_test.py
@@ -164,10 +164,12 @@ def test_shaped_data_values():
         values = np.arange(block_model.n_cells, dtype=float)
         block_model.add_data({"DataValues": {"association": "CELL", "values": values}})
         shaped = block_model.shaped_data_values("DataValues")
-        assert shaped.shape == (
-            block_model.shape[2],
-            block_model.shape[0],
-            block_model.shape[1],
-        )
-        assert np.allclose(shaped.ravel(order="F"), values)
+        assert shaped.shape == block_model.shape
+        assert np.allclose(shaped.ravel(), values)
         assert np.allclose(shaped, block_model.shaped_data_values(values))
+
+        block_model.add_data({"DataValues2": {"association": "CELL", "values": shaped}})
+
+        data1 = block_model.get_data("DataValues")[0].values
+        data2 = block_model.get_data("DataValues2")[0].values
+        assert np.allclose(data1, data2)

--- a/tests/block_model_test.py
+++ b/tests/block_model_test.py
@@ -151,3 +151,22 @@ def test_create_block_model_data(tmp_path):
             grid_copy.mask_by_extent(np.vstack([[-100, -100], [1, 100]]), inverse=True)
             == ~mask
         )
+
+
+def test_shaped_data_values():
+    with Workspace() as workspace:
+        block_model = BlockModel.create(
+            workspace,
+            u_cell_delimiters=np.array([0.0, 1.0, 2.0]),
+            v_cell_delimiters=np.array([0.0, 1.0, 2.0]),
+            z_cell_delimiters=np.array([0.0, -1.0, -2.0]),
+        )
+        values = np.arange(block_model.n_cells, dtype=float)
+        block_model.add_data({"DataValues": {"association": "CELL", "values": values}})
+        shaped = block_model.shaped_data_values("DataValues")
+        assert shaped.shape == (
+            block_model.shape[2],
+            block_model.shape[0],
+            block_model.shape[1],
+        )
+        assert np.allclose(shaped.ravel(order="F"), values)

--- a/tests/block_model_test.py
+++ b/tests/block_model_test.py
@@ -170,3 +170,4 @@ def test_shaped_data_values():
             block_model.shape[1],
         )
         assert np.allclose(shaped.ravel(order="F"), values)
+        assert np.allclose(shaped, block_model.shaped_data_values(values))

--- a/tests/grid_2d_test.py
+++ b/tests/grid_2d_test.py
@@ -184,3 +184,34 @@ def test_grid2d_to_geoimage(tmp_path):
 
         with pytest.raises(TypeError, match="The dtype of the keys must be"):
             converter.key_to_data(grid, [0, 1])
+
+
+def test_shaped_data_values():
+    n_u, n_v = 5, 4
+    with Workspace() as workspace:
+        grid = Grid2D.create(
+            workspace,
+            u_cell_size=1.0,
+            v_cell_size=1.0,
+            u_count=n_u,
+            v_count=n_v,
+        )
+        values = np.arange(grid.n_cells, dtype=float)
+        grid.add_data({"DataValues": {"association": "CELL", "values": values}})
+        shaped = grid.shaped_data_values("DataValues")
+        assert shaped.shape == (n_v, n_u)
+        assert np.allclose(shaped[::-1].flatten(), values)
+
+
+def test_get_unique_data_errors():
+    with Workspace() as workspace:
+        grid = Grid2D.create(workspace, u_count=2, v_count=2)
+
+        with pytest.raises(ValueError, match="No data"):
+            grid.shaped_data_values("NonExistent")
+
+        grid.add_data(
+            {"ObjectData": {"association": "OBJECT", "values": np.array([1.0])}}
+        )
+        with pytest.raises(ValueError, match="expected 'CELL'"):
+            grid.shaped_data_values("ObjectData")

--- a/tests/grid_2d_test.py
+++ b/tests/grid_2d_test.py
@@ -200,9 +200,15 @@ def test_shaped_data_values():
         grid.add_data({"DataValues": {"association": "CELL", "values": values}})
         shaped = grid.shaped_data_values("DataValues")
         assert shaped.shape == (n_v, n_u)
-        assert np.allclose(shaped[::-1].flatten(), values)
-
+        assert np.allclose(shaped.flatten(), values)
         assert np.allclose(shaped, grid.shaped_data_values(values))
+
+        # check for data restoration
+        grid.add_data({"DataValues2": {"association": "CELL", "values": shaped}})
+
+        data1 = grid.get_data("DataValues")[0].values
+        data2 = grid.get_data("DataValues2")[0].values
+        assert np.allclose(data1, data2)
 
 
 def test_get_unique_data_errors():

--- a/tests/grid_2d_test.py
+++ b/tests/grid_2d_test.py
@@ -202,6 +202,8 @@ def test_shaped_data_values():
         assert shaped.shape == (n_v, n_u)
         assert np.allclose(shaped[::-1].flatten(), values)
 
+        assert np.allclose(shaped, grid.shaped_data_values(values))
+
 
 def test_get_unique_data_errors():
     with Workspace() as workspace:


### PR DESCRIPTION
**GEOPY-2786 - add a mthode to access the reshaped values in geoh5py for 2d grid and 3dgrid**
add a method on grid2d and block model to access shaped data