### PR TITLE
GEOPY-2841: adapt scigeoh5 tests to use uijsons and no dicts

### DIFF
--- a/geoh5py/ui_json/validation.py
+++ b/geoh5py/ui_json/validation.py
@@ -373,9 +373,14 @@ def dependency_type_validation(name: str, ui_json: BaseUIJson):
     """
     dependency_form = getattr(ui_json, name)
 
-    if not dependency_form.optional and not isinstance(dependency_form, BoolForm):
+    if (
+        not dependency_form.optional
+        and not dependency_form.group_optional
+        and not isinstance(dependency_form, BoolForm)
+    ):
         raise UIJsonError(
-            f"Dependency form '{name}' must be either optional or of boolean type."
+            f"Dependency form '{name}' must be either "
+            f"'optional', 'group optional' or a form of boolean type."
         )
 
 

--- a/geoh5py/ui_json/validation.py
+++ b/geoh5py/ui_json/validation.py
@@ -366,7 +366,7 @@ class ErrorPool:  # pylint: disable=too-few-public-methods
 
 def dependency_type_validation(name: str, ui_json: BaseUIJson):
     """
-    Validate that the form depending on is optional or bool type.
+    Validate that the form depending on is optional, group optional or bool type.
 
     :param name: Name of the form
     :param ui_json: A UIJson object.
@@ -380,7 +380,7 @@ def dependency_type_validation(name: str, ui_json: BaseUIJson):
     ):
         raise UIJsonError(
             f"Dependency form '{name}' must be either "
-            f"'optional', 'group optional' or a form of boolean type."
+            "'optional', 'groupOptional' or a form of boolean type."
         )
 
 

--- a/tests/ui_json/uijson_test.py
+++ b/tests/ui_json/uijson_test.py
@@ -285,10 +285,17 @@ def test_validate_dependency_type_validation(tmp_path):
 
     # Non-optional non-bool dependency is invalid
     kwargs["my_parameter"].pop("optional")
-    msg = "Dependency form 'my_parameter' must be either optional or of boolean type"
+    msg = "Dependency form 'my_parameter' must be either 'optional', 'group optional' or a form of boolean type"
     with pytest.raises(UIJsonError, match=msg):
         uijson = generate_test_uijson(ws, uijson=MyBaseUIJson, data=kwargs)
         _ = uijson.to_params()
+
+    # group_optional dependency is valid
+    kwargs["my_parameter"]["group"] = "some_group"
+    kwargs["my_parameter"]["group_optional"] = True
+    uijson = generate_test_uijson(ws, uijson=MyBaseUIJson, data=kwargs)
+    params = uijson.to_params()
+    assert params["my_dependent_parameter"] == "test"
 
 
 def test_parent_child_validation(tmp_path):


### PR DESCRIPTION
**GEOPY-2841 - adapt scigeoh5 tests to use uijsons and no dicts**
in validation , check also for groupOptional, not only optional or bolean

add a unitest