### PR TITLE
DEVOPS-1060: [COPILOT Edit]: Add JIRA title trigger to PR workflow

### DIFF
--- a/.github/workflows/pr_jira_actions.yml
+++ b/.github/workflows/pr_jira_actions.yml
@@ -2,10 +2,11 @@ name: JIRA actions
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 jobs:
   call-workflow-pr_jira_actions:
+    if: github.event.action != 'edited' || github.event.changes.title != null
     uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-pr_actions.yml@v3
     permissions:
       contents: read


### PR DESCRIPTION
**DEVOPS-1060 - in github, exception on jira number check for automatic PR Bumping CI-tools**
Add conditional to JIRA workflow to only trigger validation on PR title changes when the event is 'edited'.

Part of DEVOPS-1060: add-jira-title-trigger

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>