### PR TITLE
DEVOPS-1065: [fixup] configure auto-versioning in local conda recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-﻿# Byte-compiled / optimized / DLL files
+# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class

--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -16,6 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License    '
 #  along with geoh5py.  If not, see <https://www.gnu.org/licenses/>.           '
 # ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
 from __future__ import annotations
 
 import importlib


### PR DESCRIPTION
**DEVOPS-1065 - configure auto-versioning in local conda recipes**

followup of https://github.com/MiraGeoscience/geoh5py/pull/905