### PR TITLE
GEOPY-2992: ColorMap values property should be transposed

### DIFF
--- a/geoh5py/data/color_map.py
+++ b/geoh5py/data/color_map.py
@@ -61,7 +61,7 @@ class ColorMap:
         where V (Values) are sorted floats defining the position of each RGBA.
         R (Red), G (Green), B (Blue) and A (Alpha) are integer values between [0, 255].
         """
-        return np.vstack([self._values[name] for name in self._names])
+        return np.vstack([self._values[name] for name in self._names]).T
 
     @values.setter
     def values(self, values: np.ndarray):
@@ -69,6 +69,9 @@ class ColorMap:
             raise TypeError(f"Input 'values' of ColorMap must be of type {np.ndarray}.")
 
         if np.issubdtype(values.dtype.base, np.number):
+            if values.shape[1] != 5 and values.shape[0] == 5:
+                values = values.T
+
             if values.shape[1] != 5:
                 raise ShapeValidationError("values", values.shape, "(*, 5)")
 

--- a/geoh5py/data/color_map.py
+++ b/geoh5py/data/color_map.py
@@ -69,6 +69,9 @@ class ColorMap:
             raise TypeError(f"Input 'values' of ColorMap must be of type {np.ndarray}.")
 
         if np.issubdtype(values.dtype.base, np.number):
+            if values.ndim != 2:
+                raise ValueError("Input 'values' array must have 2 dimensions.")
+
             if values.shape[1] != 5 and values.shape[0] == 5:
                 values = values.T
 

--- a/tests/data/color_map_test.py
+++ b/tests/data/color_map_test.py
@@ -34,7 +34,7 @@ def create_object_and_data(workspace: Workspace, name: str, n_x: int, n_y: int):
     values, _ = np.meshgrid(np.linspace(0, np.pi, n_x), np.linspace(0, np.pi, n_y))
 
     standalone = ColorMap()
-    assert standalone.values.shape[1] == 0
+    assert standalone.values.shape[1] == 5
 
     grid = Grid2D.create(
         workspace,
@@ -75,9 +75,9 @@ def test_create_color_map(tmp_path):
         data.entity_type.color_map = 1234
 
     with pytest.raises(ShapeValidationError) as error:
-        data.entity_type.color_map = rgba.T
+        data.entity_type.color_map = np.array([[1, 2]])
 
-    assert ShapeValidationError.message("values", "(5, 10)", "(*, 5)") == str(
+    assert ShapeValidationError.message("values", "(1, 2)", "(*, 5)") == str(
         error.value
     )
 

--- a/tests/data/color_map_test.py
+++ b/tests/data/color_map_test.py
@@ -165,3 +165,26 @@ def test_color_map_filter(tmp_path):
             rec_data.entity_type.filter_max, np.percentile(data.values, 70)
         )
         assert not rec_data.entity_type.filter_min
+
+
+def test_color_map_circular_values():
+    values = np.array(
+        [
+            [0, 90, 90, 90, 0],
+            [1, 255, 51, 51, 255],
+        ]
+    )
+    color_map = ColorMap(values=values)
+    new_color_map = ColorMap(values=color_map.values)
+    assert np.allclose(color_map.values, new_color_map.values)
+
+
+def test_color_map_values_setter():
+    values = np.array(
+        [
+            [0, 90, 90, 90, 0],
+            [1, 255, 51, 51, 255],
+        ]
+    )
+    color_map = ColorMap(values=values.T)
+    assert np.allclose(values, color_map.values)


### PR DESCRIPTION
**GEOPY-2992 - ColorMap values property should be transposed**
…he same format that you set them and allow passing the transpose of the correct shape for convenience