### PR TITLE
DEVOPS-1133: Pin GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,17 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  call-workflow-dependabot-auto-merge:
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-dependabot-auto-merge.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
+      checks: read
+    with:
+      dependabot-groups: mirageo-ci-tools,pre-commit-hooks
+      checks-to-skip: 'pre-commit.ci - pr,CodeQL'

--- a/.github/workflows/issue_to_jira.yml
+++ b/.github/workflows/issue_to_jira.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   call-workflow-create-jira-issue:
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@v3
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/pr_jira_actions.yml
+++ b/.github/workflows/pr_jira_actions.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   call-workflow-pr_jira_actions:
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-pr_actions.yml@v3
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-pr_actions.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   call-workflow-static-analysis:
     name: Static analysis
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@v3
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
     permissions:
       contents: read
       pull-requests: read
@@ -36,7 +36,7 @@ jobs:
       python-version: '3.12'
   call-workflow-pytest:
     name: Pytest
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@v3
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/python_deploy_dev.yml
+++ b/.github/workflows/python_deploy_dev.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   call-workflow-conda-publish:
     name: Publish development conda package on JFrog Artifactory
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-publish_rattler_package.yml@v3
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-publish_rattler_package.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
     permissions:
       contents: write
     with:
@@ -29,7 +29,7 @@ jobs:
       JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
   call-workflow-pypi-publish:
     name: Publish development pypi package (JFrog Artifactory, TestPyPI)
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-publish_pypi_package.yml@v3
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-publish_pypi_package.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
     permissions:
       contents: write
     with:

--- a/.github/workflows/python_deploy_prod.yml
+++ b/.github/workflows/python_deploy_prod.yml
@@ -53,7 +53,7 @@ jobs:
     name: Publish production Conda package on JFrog Artifactory
     needs: validate-release-tag
     if: ${{ github.event_name == 'release' || github.event.inputs.publish-conda == 'true' }}
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-release_conda_assets.yml@v3
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-release_conda_assets.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
     permissions:
       contents: write
     with:
@@ -66,7 +66,7 @@ jobs:
     name: Publish production PyPI package (JFrog Artifactory, PyPI)
     needs: validate-release-tag
     if: ${{ github.event_name == 'release' || github.event.inputs.publish-pypi == 'true' }}
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-release_pypi_assets.yml@v3
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-release_pypi_assets.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
     permissions:
       contents: write
     with:

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -31,7 +31,7 @@ jobs:
       security-events: write
       contents: read
       actions: read
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-zizmor-advanced-security.yml@v3
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-zizmor-advanced-security.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
 
   call-workflow-zizmor-annotate:
     name: Zizmor analysis (annotate)
@@ -40,4 +40,4 @@ jobs:
       checks: write
       contents: read
       actions: read
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-zizmor-annotate.yml@v3
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-zizmor-annotate.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0

--- a/.github/workflows/wip-status.yml
+++ b/.github/workflows/wip-status.yml
@@ -1,0 +1,12 @@
+name: WIP status
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+
+jobs:
+  call-workflow-wip-status:
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-wip-status.yml@7241532854727d993872b67fc761139b8438615b # v3.12.0
+    permissions:
+      contents: read
+      statuses: write


### PR DESCRIPTION
**DEVOPS-1133 - pin all GitHub actions and reusable workflows to hash**
Expands moving GitHub Actions tags to the full semver tag pointing at the same commit, then pins every `uses:` to a commit hash with a dependabot-readable version comment.

Tags expanded in this repo:

- `MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@v3 -> @v3.12.0`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-jira-pr_actions.yml@v3 -> @v3.12.0`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@v3 -> @v3.12.0`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@v3 -> @v3.12.0`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-python-publish_rattler_package.yml@v3 -> @v3.12.0`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-python-publish_pypi_package.yml@v3 -> @v3.12.0`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-python-release_conda_assets.yml@v3 -> @v3.12.0`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-python-release_pypi_assets.yml@v3 -> @v3.12.0`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-zizmor-advanced-security.yml@v3 -> @v3.12.0`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-zizmor-annotate.yml@v3 -> @v3.12.0`

Workflows added:

- `.github/workflows/dependabot-auto-merge.yml`
- `.github/workflows/wip-status.yml`

All `MiraGeoscience/CI-tools` reusable workflows are pinned to `7241532854727d993872b67fc761139b8438615b` (**v3.12.0**).
