### PR TITLE
GEOPY-3022: Crash opening workspace containing PropertyGroup with no name

### DIFF
--- a/geoh5py/groups/property_group.py
+++ b/geoh5py/groups/property_group.py
@@ -68,19 +68,20 @@ class PropertyGroup:
         *,
         association: str | DataAssociationEnum | None = None,
         allow_delete: bool = True,
-        name: str = "Property Group",
+        name: str = "Data Group",
         on_file: bool = False,
         uid: UUID | None = None,
-        property_group_type: GroupTypeEnum | str = GroupTypeEnum.SIMPLE,
+        property_group_type: GroupTypeEnum | str = GroupTypeEnum.MULTI,
         properties: Sequence[UUID | Data | str] | None = None,
         **_,
     ):
         self._parent: ObjectBase = self._validate_parent(parent)
         self._property_group_type = self._validate_group_type(property_group_type)
+        self._on_file = False
 
         self.allow_delete = allow_delete
         self.name = name
-        self.on_file = on_file
+
         self.uid = uid or uuid4()
 
         properties_list = self._initialize_properties(properties)
@@ -89,6 +90,7 @@ class PropertyGroup:
         self._properties = self._validate_properties(properties_list)
 
         self.parent.add_children([self])
+        self.on_file = on_file
         self.parent.workspace.register(self)
 
     def _initialize_properties(
@@ -306,6 +308,9 @@ class PropertyGroup:
                 )
 
         self._name = new_name
+
+        if self.on_file:
+            self.parent.workspace.add_or_update_property_group(self)
 
     @property
     def on_file(self):

--- a/geoh5py/objects/object_base.py
+++ b/geoh5py/objects/object_base.py
@@ -433,23 +433,17 @@ class ObjectBase(EntityContainer):
 
     def create_property_group(
         self,
-        name=None,
-        property_group_type: GroupTypeEnum | str = GroupTypeEnum.MULTI,
         **kwargs,
     ) -> PropertyGroup:
         """
         Create a new :obj:`~geoh5py.groups.property_group.PropertyGroup`.
 
-        :param name: Name of the new property group.
-        :param property_group_type: Type of property group.
         :param kwargs: Any arguments taken by the
             :obj:`~geoh5py.groups.property_group.PropertyGroup` class.
 
         :return: A new :obj:`~geoh5py.groups.property_group.PropertyGroup`
         """
-        prop_group = PropertyGroup(
-            self, name=name, property_group_type=property_group_type, **kwargs
-        )
+        prop_group = PropertyGroup(self, **kwargs)
 
         return prop_group
 

--- a/geoh5py/shared/concatenation/object.py
+++ b/geoh5py/shared/concatenation/object.py
@@ -52,14 +52,12 @@ class ConcatenatedObject(Concatenated, ObjectBase):
 
     def create_property_group(
         self,
-        name=None,
         property_group_type: GroupTypeEnum | str = GroupTypeEnum.INTERVAL,
         **kwargs,
     ) -> ConcatenatedPropertyGroup:
         """
         Create a new :obj:`~geoh5py.groups.property_group.PropertyGroup`.
 
-        :param name: Name of the property group.
         :param property_group_type: Type of property group.
         :param kwargs: Any arguments taken by the
             :obj:`~geoh5py.groups.property_group.PropertyGroup` class.
@@ -67,7 +65,7 @@ class ConcatenatedObject(Concatenated, ObjectBase):
         :return: A new :obj:`~geoh5py.groups.property_group.PropertyGroup`
         """
         prop_group = ConcatenatedPropertyGroup(
-            self, name=name, property_group_type=property_group_type, **kwargs
+            self, property_group_type=property_group_type, **kwargs
         )
 
         return prop_group

--- a/tests/groups/property_group_test.py
+++ b/tests/groups/property_group_test.py
@@ -27,7 +27,7 @@ from geoh5py.data import Data, DataAssociationEnum
 from geoh5py.groups import PropertyGroup
 from geoh5py.groups.property_group import GroupTypeEnum
 from geoh5py.groups.property_group_table import PropertyGroupTable
-from geoh5py.objects import Curve, Drillhole
+from geoh5py.objects import Curve, Drillhole, ObjectBase
 from geoh5py.workspace import Workspace
 
 
@@ -300,6 +300,21 @@ def test_property_group_same_name(tmp_path):
             "myGroup",
             "myGroup(1)",
         ]
+
+
+def test_property_group_name_change(tmp_path):
+    h5file_path = tmp_path / f"{__name__}.geoh5"
+
+    with Workspace.create(h5file_path) as workspace:
+        curve, _ = make_example(workspace)
+
+        curve.property_groups[0].name = "Name changed"
+
+    with Workspace(h5file_path) as workspace:
+        # error here if a property group has the same name
+        curve = workspace.get_entity(curve.uid)[0]
+
+        assert sorted([pg.name for pg in curve.property_groups]) == ["Name changed"]
 
 
 def test_clean_out_empty(tmp_path):

--- a/tests/groups/property_group_test.py
+++ b/tests/groups/property_group_test.py
@@ -27,7 +27,7 @@ from geoh5py.data import Data, DataAssociationEnum
 from geoh5py.groups import PropertyGroup
 from geoh5py.groups.property_group import GroupTypeEnum
 from geoh5py.groups.property_group_table import PropertyGroupTable
-from geoh5py.objects import Curve, Drillhole, ObjectBase
+from geoh5py.objects import Curve, Drillhole
 from geoh5py.workspace import Workspace
 
 


### PR DESCRIPTION
**GEOPY-3022 - Crash opening workspace containing PropertyGroup with no name**
