### PR TITLE
GEOPY-3045: Missing unit conversion for Frequency systems

### DIFF
--- a/geoh5py/objects/surveys/electromagnetics/base.py
+++ b/geoh5py/objects/surveys/electromagnetics/base.py
@@ -474,7 +474,7 @@ class BaseEMSurvey(BaseSurvey, ABC):  # pylint: disable=too-many-public-methods
             self.edit_em_metadata({"Tx ID tx property": getattr(value, "uid", None)})
 
     @property
-    def unit(self) -> float | None:
+    def unit(self) -> str | None:
         """
         Default channel units for time or frequency defined on the child class.
         """
@@ -885,7 +885,7 @@ class AirborneEMSurvey(BaseEMSurvey, Curve, ABC):
 
 
 class FEMSurvey(BaseEMSurvey, ABC):
-    __UNITS = __UNITS = [
+    __UNITS = [
         "Hertz (Hz)",
         "KiloHertz (kHz)",
         "MegaHertz (MHz)",


### PR DESCRIPTION
**GEOPY-3045 - Missing unit conversion for Frequency systems**
